### PR TITLE
Implement year, make, and model extraction and normalization

### DIFF
--- a/app/sources/bat/transform.py
+++ b/app/sources/bat/transform.py
@@ -19,8 +19,15 @@ def transform_listing_html(listing_id):
     soup = BeautifulSoup(html, "html.parser")
     product_data = get_product_json_ld(soup)
     listing_title = extract_listing_title(soup, product_data)
+    year = parse_year(listing_title)
+    make = parse_make(soup)
+    model = parse_model(soup)
     # Placeholder for transformation logic - to be implemented
-    transformed_data = {}
+    transformed_data = {
+        "make": make,
+        "model": model,
+        "year": year
+    }
     return transformed_data
 
 def store_transformed_data(listing_id, data):
@@ -65,3 +72,36 @@ def _strip_listing_prefix(title):
     if not match:
         raise ValueError("Could not parse listing title")
     return match.group(1).strip()
+
+def parse_year(title):
+    match = re.match(r"(\d{4})", title)
+    if not match:
+        raise ValueError("Could not parse year from listing title")
+    return int(match.group(1))
+
+def parse_model(soup):
+   return extract_group_value(soup, "Model")
+
+def parse_make(soup):
+    return extract_group_value(soup, "Make")
+
+def extract_group_value(soup: BeautifulSoup, label: str) -> str:
+    for button in soup.select("button.group-title"):
+        label_tag = button.select_one("strong.group-title-label")
+        if not label_tag:
+            continue
+
+        if label_tag.get_text(strip=True) != label:
+            continue
+
+        # Get the button text, then remove the label text from the front
+        full_text = button.get_text(" ", strip=True)
+        label_text = label_tag.get_text(" ", strip=True)
+
+        value = full_text.removeprefix(label_text).strip()
+        if not value:
+            raise ValueError(f"Found '{label}' group but it had no value")
+
+        return value
+
+    raise ValueError(f"Could not find '{label}' group")

--- a/tests/unit/bat/test_transform.py
+++ b/tests/unit/bat/test_transform.py
@@ -230,3 +230,73 @@ def test_extract_listing_title_not_found():
     with pytest.raises(ValueError, match="Could not parse listing title"):
         extract_listing_title(soup, product_data)
     
+def test_parse_year_valid_title():
+    title = "2026 Make Model Title"
+    year = parse_year(title)
+    assert year == 2026
+
+def test_parse_year_invalid_title():
+    title = "Make Model Title"
+    with pytest.raises(ValueError, match="Could not parse year from listing title"):
+        parse_year(title)
+
+def test_parse_model_valid():
+    html_content = """
+    <html>
+        <body>
+            <button class="group-title">
+                <strong class="group-title-label">Model</strong>
+                Model Name
+            </button>
+        </body>
+    </html>
+    """
+    soup = BeautifulSoup(html_content, "html.parser")
+    model = parse_model(soup)
+    assert model == "Model Name"
+
+def test_parse_model_not_found():
+    html_content = """
+    <html>
+        <body>
+            <button class="group-title">
+                <strong class="group-title-label">Make</strong>
+                Make Name
+            </button>
+        </body>
+    </html>
+    """
+    soup = BeautifulSoup(html_content, "html.parser")
+    with pytest.raises(ValueError, match="Could not find 'Model' group"):
+        parse_model(soup)
+
+def test_parse_make_valid():
+    html_content = """
+    <html>
+        <body>
+            <button class="group-title">
+                <strong class="group-title-label">Make</strong>
+                Make Name
+            </button>
+        </body>
+    </html>
+    """
+    soup = BeautifulSoup(html_content, "html.parser")
+    make = parse_make(soup)
+    assert make == "Make Name"
+
+def test_parse_make_not_found():
+    html_content = """
+    <html>
+        <body>
+            <button class="group-title">
+                <strong class="group-title-label">Model</strong>
+                Model Name
+            </button>
+        </body>
+    </html>
+    """
+    soup = BeautifulSoup(html_content, "html.parser")
+    with pytest.raises(ValueError, match="Could not find 'Make' group"):
+        parse_make(soup)
+


### PR DESCRIPTION
Summary
Implements extraction and normalization of listing year, make, and model during BAT listing transformation.

What changed
- Updated transform_listing_html() to parse and return year, make, and model in the transformed output instead of returning an empty placeholder dict.
- Added parse_year() to extract the 4-digit year from the normalized listing title and return it as an integer.
- Added parse_make() and parse_model() using shared group-button parsing logic rather than relying on title-only parsing.
- Added extract_group_value() to locate BAT metadata buttons like Make and Model, remove the label text, and return the cleaned value with clear error handling for missing or empty fields.

Testing
Expanded tests/unit/bat/test_transform.py with unit coverage for the new year, make, and model parsing behavior and the shared group-value extraction path.