### PR TITLE
Implement listing details extraction and corresponding unit tests

### DIFF
--- a/app/sources/bat/transform.py
+++ b/app/sources/bat/transform.py
@@ -105,3 +105,21 @@ def extract_group_value(soup: BeautifulSoup, label: str) -> str:
         return value
 
     raise ValueError(f"Could not find '{label}' group")
+
+def get_listing_details(soup):
+    details_header = soup.find("strong", string=re.compile(r"Listing Details"))
+    if not details_header:
+        raise ValueError("Could not parse listing details")
+
+    details_container = details_header.find_parent("div", class_="item")
+    details_list = details_container.find("ul") if details_container else None
+    if not details_list:
+        raise ValueError("Could not parse listing details")
+
+    values = [item.get_text(" ", strip=True) for item in details_list.find_all("li")]
+    if not values:
+        raise ValueError("Could not parse listing details")
+    return values
+
+
+

--- a/tests/unit/bat/test_transform.py
+++ b/tests/unit/bat/test_transform.py
@@ -299,4 +299,57 @@ def test_parse_make_not_found():
     soup = BeautifulSoup(html_content, "html.parser")
     with pytest.raises(ValueError, match="Could not find 'Make' group"):
         parse_make(soup)
+    
+def test_get_listing_details_valid():
+    html_content = """
+    <html>
+        <body>
+            <div class="item">
+                <strong>Listing Details</strong>
+                <ul>
+                    <li>Chassis: <a href="test-url">WBSBL93414PN57203</a></li>
+                    <li>100k Miles</li>
+                    <li>3.2-Liter S54 Inline-Six</li>
+                </ul>
+            </div>
+        </body>
+    </html>
+    """
+    soup = BeautifulSoup(html_content, "html.parser")
+    details = get_listing_details(soup)
+    assert details == [
+        "Chassis: WBSBL93414PN57203",
+        "100k Miles",
+        "3.2-Liter S54 Inline-Six",
+    ]
 
+def test_get_listing_details_not_found():
+    html_content = """
+    <html>
+        <body>
+            <div class="item">
+                <strong>Other Details</strong>
+                <ul>
+                    <li>100k Miles</li>
+                </ul>
+            </div>
+        </body>
+    </html>
+    """
+    soup = BeautifulSoup(html_content, "html.parser")
+    with pytest.raises(ValueError, match="Could not parse listing details"):
+        get_listing_details(soup)
+
+def test_get_listing_details_no_list():
+    html_content = """
+    <html>
+        <body>
+            <div class="item">
+                <strong>Listing Details</strong>
+            </div>
+        </body>
+    </html>
+    """
+    soup = BeautifulSoup(html_content, "html.parser")
+    with pytest.raises(ValueError, match="Could not parse listing details"):
+        get_listing_details(soup)


### PR DESCRIPTION
Summary
Adds BAT listing details extraction and test coverage.

What changed
Added get_listing_details(soup) to extract cleaned values from the Listing Details section
Added error handling when the section or expected list content is missing
Added unit tests for the happy path and missing-details case

Why
The Listing Details section contains reusable structured metadata for downstream field parsing.