### PR TITLE
Implement mileage parsing and detail extraction in transformation logic

### DIFF
--- a/app/sources/bat/transform.py
+++ b/app/sources/bat/transform.py
@@ -19,14 +19,20 @@ def transform_listing_html(listing_id):
     soup = BeautifulSoup(html, "html.parser")
     product_data = get_product_json_ld(soup)
     listing_title = extract_listing_title(soup, product_data)
+    listing_details = get_listing_details(soup)
+
+    # transformed entries
     year = parse_year(listing_title)
     make = parse_make(soup)
     model = parse_model(soup)
+    mileage = parse_mileage(find_detail_value(listing_details, r"\bmiles?\b|\btmu\b|\bunknown\b", "Mileage"))
+
     # Placeholder for transformation logic - to be implemented
     transformed_data = {
         "make": make,
         "model": model,
-        "year": year
+        "year": year,
+        "mileage": mileage,
     }
     return transformed_data
 
@@ -121,5 +127,25 @@ def get_listing_details(soup):
         raise ValueError("Could not parse listing details")
     return values
 
+# Find the corresponding value for a given field in the listing details
+def find_detail_value(values, pattern, field_name):
+    for value in values:
+        if re.search(pattern, value, re.IGNORECASE):
+            return value
+    raise ValueError(f"Could not parse {field_name}")
 
+def parse_mileage(raw_mileage):
+    mileage = raw_mileage.strip().lower()
 
+    if "tmu" in mileage or "unknown" in mileage:
+        return None
+
+    match = re.search(r"(\d{1,3}(?:,\d{3})*|\d+)(k)?\s+miles\b", mileage)
+    if not match:
+        raise ValueError(f"Could not parse mileage")
+
+    mileage = int(match.group(1).replace(",", ""))
+    if match.group(2):
+        mileage *= 1000
+
+    return mileage

--- a/tests/unit/bat/test_transform.py
+++ b/tests/unit/bat/test_transform.py
@@ -353,3 +353,56 @@ def test_get_listing_details_no_list():
     soup = BeautifulSoup(html_content, "html.parser")
     with pytest.raises(ValueError, match="Could not parse listing details"):
         get_listing_details(soup)
+
+def test_parse_mileage_valid():
+    assert parse_mileage("100k Miles") == 100000
+    assert parse_mileage("50,000 Miles") == 50000
+    assert parse_mileage("100 miles") == 100
+
+def test_parse_mileage_TMU():
+    assert parse_mileage("TMU") == None
+    assert parse_mileage("Mileage Unknown") == None
+
+def test_parse_mileage_invalid():
+    with pytest.raises(ValueError, match="Could not parse mileage"):
+        parse_mileage("")
+
+def test_find_detail_value_valid_miles_with_k():
+    values = [
+        "Chassis: WBSBL93414PN57203",
+        "100k Miles",
+        "3.2-Liter S54 Inline-Six",
+    ]
+    assert find_detail_value(values, r"\bmiles?\b|\btmu\b|\bunknown\b", "Mileage") == "100k Miles"
+
+def test_find_detail_value_valid_miles_without_k():
+    values = [
+        "Chassis: WBSBL93414PN57203",
+        "2,500 Miles",
+        "3.2-Liter S54 Inline-Six",
+    ]
+    assert find_detail_value(values, r"\bmiles?\b|\btmu\b|\bunknown\b", "Mileage") == "2,500 Miles"
+
+def test_find_detail_value_valid_miles_and_tmu():
+    values = [
+        "Chassis: WBSBL93414PN57203",
+        "2,500 Miles, TMU",
+        "3.2-Liter S54 Inline-Six",
+    ]
+    assert find_detail_value(values, r"\bmiles?\b|\btmu\b|\bunknown\b", "Mileage") == "2,500 Miles, TMU"
+
+def test_find_detail_value_valid_tmu_only():
+    values = [
+        "Chassis: WBSBL93414PN57203",
+        "TMU",
+        "3.2-Liter S54 Inline-Six",
+    ]
+    assert find_detail_value(values, r"\bmiles?\b|\btmu\b|\bunknown\b", "Mileage") == "TMU"
+
+def test_find_detail_value_not_found():
+    values = [
+        "Chassis: WBSBL93414PN57203",
+        "3.2-Liter S54 Inline-Six",
+    ]
+    with pytest.raises(ValueError, match="Could not parse Mileage"):
+        find_detail_value(values, r"\bmiles?\b|\btmu\b|\bunknown\b", "Mileage")


### PR DESCRIPTION
Summary
Adds mileage extraction and parsing to BAT transformation logic.

What changed
- Added get_listing_details(soup) output into transform_listing_html() and now derives mileage from the listing details section.
- Added find_detail_value() to locate the matching detail entry by regex pattern.
- Added parse_mileage() to normalize mileage values, returning an integer for numeric mileage and None for TMU/unknown cases.
- Updated the transformed output to include mileage.

Testing
- Added unit tests covering valid mileage parsing, TMU/unknown handling, and detail-value extraction behavior.