### PR TITLE
Define MVP listings schema

### DIFF
--- a/.runs/postgres-schema/issue-34/00-issue.md
+++ b/.runs/postgres-schema/issue-34/00-issue.md
@@ -1,0 +1,44 @@
+# Issue #34: Define MVP listings table schema
+
+URL: https://github.com/Cameron831/car-auction-etl/issues/34
+
+## Type
+
+feature
+
+## Priority
+
+high
+
+## Depends On
+
+None
+
+## Labels
+
+- database
+- schema
+
+## Goal
+
+Update the Postgres schema so the listings table can store the current transformed Bring a Trailer listing output.
+
+## Scope
+
+- Update `sql/schema.sql` with the MVP listings table columns.
+- Preserve uniqueness on `source_site` and `source_listing_id`.
+- Add low-risk constraints for `year`, `mileage`, `sale_price`, and `transmission`.
+- Add indexes for `auction_end_date` and `vin` where useful.
+- Keep raw HTML artifact storage out of the database schema.
+
+## Acceptance Criteria
+
+- `listings` includes `source_site`, `source_listing_id`, `url`, `make`, `model`, `year`, `mileage`, `vin`, `sale_price`, `sold`, `auction_end_date`, `transmission`, `listing_details_raw`, `created_at`, and `updated_at`.
+- `auction_end_date` is `DATE`.
+- `sale_price` is `NOT NULL` and represents the displayed amount, including bid-to amount for unsold listings.
+- `listing_details_raw` is `JSONB`.
+- Source uniqueness is enforced by `source_site` and `source_listing_id`.
+
+## Notes
+
+Use one canonical `listings` table for the MVP rather than normalizing into source, vehicle, auction, and sale tables.

--- a/.runs/postgres-schema/issue-34/01-execution-plan.md
+++ b/.runs/postgres-schema/issue-34/01-execution-plan.md
@@ -1,0 +1,77 @@
+# Execution Plan: Issue #34
+
+## Workflow
+
+Issue to PR
+
+## Stage
+
+Plan issue
+
+## Input Artifact
+
+- `.runs/postgres-schema/issue-34/00-issue.md`
+
+## Output Artifact
+
+- `.runs/postgres-schema/issue-34/01-execution-plan.md`
+
+## Goal
+
+Update `sql/schema.sql` so the canonical `listings` table can store the MVP Bring a Trailer transformed listing output, while preserving source uniqueness and keeping raw HTML artifact storage out of the schema.
+
+## Scope
+
+In scope:
+
+- Update the existing `listings` table definition in `sql/schema.sql`.
+- Add the MVP listing columns: `url`, `make`, `model`, `year`, `mileage`, `vin`, `sale_price`, `sold`, `auction_end_date`, `transmission`, and `listing_details_raw`.
+- Keep `source_site` and `source_listing_id` uniqueness enforced.
+- Add conservative constraints for `year`, `mileage`, `sale_price`, and `transmission`.
+- Add indexes for `auction_end_date` and `vin` if useful.
+
+Out of scope:
+
+- Insert/upsert/application persistence changes.
+- Docker or bootstrap wiring.
+- Schema verification tests.
+- Normalizing into separate source, vehicle, auction, or sale tables.
+- Storing raw HTML artifacts in Postgres.
+
+## Assumptions
+
+- The current `listings` table can be evolved in place without a migration strategy as part of this issue.
+- Existing uniqueness on `(source_site, source_listing_id)` remains the canonical source identity rule.
+- The schema should match the current transformed output rather than over-normalizing for future sources.
+
+## Implementation Steps
+
+1. Edit `sql/schema.sql` to replace the minimal listings shape with the approved MVP canonical columns while keeping `id`, timestamps, and source uniqueness.
+2. Replace the current `raw_url` and `title` shape with the accepted schema fields, including `url` and the transformed listing attributes.
+3. Add low-risk constraints:
+   - `year` sanity check.
+   - `mileage >= 0` when present.
+   - `sale_price >= 0` and `NOT NULL`.
+   - `transmission` constrained to current normalized values when present, expected to be `manual` or `automatic`.
+4. Add indexes on `auction_end_date` and `vin` if they are not already covered.
+5. Review the final DDL against the issue acceptance criteria without adding tests, persistence code, or Docker initialization wiring.
+
+## Files Expected To Change
+
+- `sql/schema.sql`
+
+## Risks
+
+- Constraint definitions could be too strict if they do not match current transformed listing values.
+- Because this is not a migration issue, any existing local database volume may require later initialization/reset handling in issue #35.
+
+## Verification Notes
+
+- Review `sql/schema.sql` to confirm the final column list matches the issue acceptance criteria.
+- Confirm the uniqueness rule remains on `source_site` and `source_listing_id`.
+- Confirm `auction_end_date` is `DATE`, `sale_price` is `NOT NULL`, and `listing_details_raw` is `JSONB`.
+- Do not add schema tests or persistence code as part of this issue.
+
+## Stop Point
+
+Wait for user approval before starting implementation or editing code.

--- a/.runs/postgres-schema/issue-34/02-change-summary.md
+++ b/.runs/postgres-schema/issue-34/02-change-summary.md
@@ -1,0 +1,14 @@
+# Change Summary: Issue #34
+
+Updated `sql/schema.sql` to define the MVP canonical `listings` table for transformed Bring a Trailer listings.
+
+Changes:
+- Replaced the minimal `raw_url` and `title` shape with `url`, `make`, `model`, `year`, `mileage`, `vin`, `sale_price`, `sold`, `auction_end_date`, `transmission`, and `listing_details_raw`.
+- Kept `id`, `source_site`, `source_listing_id`, `created_at`, `updated_at`, and the unique constraint on `(source_site, source_listing_id)`.
+- Set `auction_end_date` to `DATE NOT NULL`, `sale_price` to `INTEGER NOT NULL`, and `listing_details_raw` to `JSONB`.
+- Added conservative checks for `year`, `mileage`, `sale_price`, and `transmission`.
+- Added indexes for `auction_end_date` and non-null `vin` values.
+
+Verification:
+- Reviewed `sql/schema.sql` against the approved acceptance criteria.
+- Did not add tests, persistence code, Docker wiring, or raw HTML artifact storage.

--- a/.runs/postgres-schema/issue-34/03-change-diff.patch
+++ b/.runs/postgres-schema/issue-34/03-change-diff.patch
@@ -1,0 +1,36 @@
+diff --git a/sql/schema.sql b/sql/schema.sql
+--- a/sql/schema.sql
++++ b/sql/schema.sql
+@@ -3,11 +3,31 @@ CREATE TABLE IF NOT EXISTS listings (
+     id BIGSERIAL PRIMARY KEY,
+     source_site TEXT NOT NULL,
+     source_listing_id TEXT NOT NULL,
+-    raw_url TEXT,
+-    title TEXT NOT NULL,
++    url TEXT NOT NULL,
++    make TEXT NOT NULL,
++    model TEXT NOT NULL,
++    year INTEGER NOT NULL,
++    mileage INTEGER,
++    vin TEXT,
++    sale_price INTEGER NOT NULL,
++    sold BOOLEAN NOT NULL,
++    auction_end_date DATE NOT NULL,
++    transmission TEXT,
++    listing_details_raw JSONB,
+     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+-    UNIQUE (source_site, source_listing_id)
++    UNIQUE (source_site, source_listing_id),
++    CONSTRAINT listings_year_check CHECK (year >= 1886 AND year <= 2100),
++    CONSTRAINT listings_mileage_check CHECK (mileage IS NULL OR mileage >= 0),
++    CONSTRAINT listings_sale_price_check CHECK (sale_price >= 0),
++    CONSTRAINT listings_transmission_check CHECK (transmission IS NULL OR transmission IN ('manual', 'automatic'))
+ );
++
++CREATE INDEX IF NOT EXISTS listings_auction_end_date_idx
++    ON listings (auction_end_date);
++
++CREATE INDEX IF NOT EXISTS listings_vin_idx
++    ON listings (vin)
++    WHERE vin IS NOT NULL;

--- a/.runs/postgres-schema/issue-34/04-test-execution-plan.md
+++ b/.runs/postgres-schema/issue-34/04-test-execution-plan.md
@@ -1,0 +1,75 @@
+# Test Execution Plan: Issue #34
+
+## Workflow
+
+Issue to PR
+
+## Stage
+
+Test planning
+
+## Input Artifacts
+
+- `.runs/postgres-schema/issue-34/01-execution-plan.md`
+- `.runs/postgres-schema/issue-34/02-change-summary.md`
+- `.runs/postgres-schema/issue-34/03-change-diff.patch`
+
+## Output Artifact
+
+- `.runs/postgres-schema/issue-34/04-test-execution-plan.md`
+
+## Goal
+
+Validate the approved `sql/schema.sql` change by review-only checks that the canonical `listings` table matches Issue #34, without adding schema verification tests in this issue.
+
+## Recommendation
+
+Do not add automated tests in this issue.
+
+Reason: the approved execution plan explicitly kept schema verification tests out of scope, and issue #36 separately covers schema verification checks. For issue #34, validation should be limited to reviewing the DDL and confirming it matches the accepted schema shape.
+
+## Scope
+
+In scope:
+
+- Manual validation of the final DDL against the issue acceptance criteria.
+- Review of column set, constraints, indexes, and uniqueness in `sql/schema.sql`.
+
+Out of scope:
+
+- Automated schema verification tests.
+- Insert/upsert/app persistence tests.
+- Docker initialization wiring tests.
+- Behavior beyond Issue #34.
+
+## Verification Steps
+
+1. Review `sql/schema.sql` directly.
+2. Verify the `listings` columns include `source_site`, `source_listing_id`, `url`, `make`, `model`, `year`, `mileage`, `vin`, `sale_price`, `sold`, `auction_end_date`, `transmission`, `listing_details_raw`, `created_at`, and `updated_at`.
+3. Confirm `auction_end_date` is `DATE NOT NULL`.
+4. Confirm `sale_price` is `INTEGER NOT NULL` with a non-negative check.
+5. Confirm `listing_details_raw` is `JSONB`.
+6. Confirm uniqueness remains on `(source_site, source_listing_id)`.
+7. Confirm indexes exist for `auction_end_date` and non-null `vin`.
+
+## Commands
+
+```powershell
+Get-Content sql/schema.sql
+Select-String -Path sql/schema.sql -Pattern "CREATE TABLE IF NOT EXISTS listings", "UNIQUE", "auction_end_date", "sale_price", "listing_details_raw", "CREATE INDEX"
+```
+
+`git diff -- sql/schema.sql` would normally be useful, but git repository detection has been unreliable in this sandbox due to the local safe-directory/ownership state. Use the patch artifact at `.runs/postgres-schema/issue-34/03-change-diff.patch` as the canonical diff if git remains unavailable.
+
+## Risks
+
+- Review-only validation does not execute PostgreSQL-specific enforcement.
+- Adding automated schema checks here would duplicate issue #36 and expand the approved scope.
+
+## Files Expected To Change
+
+- None.
+
+## Stop Point
+
+Wait for user approval before running verification commands or creating the verification log.

--- a/.runs/postgres-schema/issue-34/05-test-diff.patch
+++ b/.runs/postgres-schema/issue-34/05-test-diff.patch
@@ -1,0 +1,4 @@
+No test files changed for Issue #34.
+
+Automated tests were intentionally not added per the approved test execution plan.
+Verification for this issue is review-only because schema verification tests are covered by issue #36 and Docker init verification is covered by issue #35.

--- a/.runs/postgres-schema/issue-34/06-verification-log.md
+++ b/.runs/postgres-schema/issue-34/06-verification-log.md
@@ -1,0 +1,60 @@
+# Verification Log
+
+Issue: #34
+
+## Scope
+
+- No automated tests were added.
+- No automated tests were run.
+- Verification was review-only per the approved test execution plan.
+- No files outside `.runs/postgres-schema/issue-34/05-test-diff.patch` and `.runs/postgres-schema/issue-34/06-verification-log.md` were edited for this test implementation stage.
+
+## Commands Run
+
+```powershell
+Get-Content sql/schema.sql
+```
+
+Result: Passed review. `sql/schema.sql` defines `CREATE TABLE IF NOT EXISTS listings` with the required columns:
+
+- `source_site`
+- `source_listing_id`
+- `url`
+- `make`
+- `model`
+- `year`
+- `mileage`
+- `vin`
+- `sale_price`
+- `sold`
+- `auction_end_date`
+- `transmission`
+- `listing_details_raw`
+- `created_at`
+- `updated_at`
+
+Confirmed details:
+
+- `auction_end_date` is `DATE NOT NULL`.
+- `sale_price` is `INTEGER NOT NULL`.
+- `listing_details_raw` is `JSONB`.
+- Uniqueness remains on `(source_site, source_listing_id)`.
+
+```powershell
+Select-String -Path sql/schema.sql -Pattern "CREATE TABLE IF NOT EXISTS listings", "UNIQUE", "auction_end_date", "sale_price", "listing_details_raw", "CREATE INDEX"
+```
+
+Result: Passed review. Matches confirmed:
+
+- `CREATE TABLE IF NOT EXISTS listings`
+- `sale_price INTEGER NOT NULL`
+- `auction_end_date DATE NOT NULL`
+- `listing_details_raw JSONB`
+- `UNIQUE (source_site, source_listing_id)`
+- `CONSTRAINT listings_sale_price_check CHECK (sale_price >= 0)`
+- `CREATE INDEX IF NOT EXISTS listings_auction_end_date_idx` on `auction_end_date`
+- `CREATE INDEX IF NOT EXISTS listings_vin_idx` with `WHERE vin IS NOT NULL`
+
+## Conclusion
+
+Review-only verification passed for the approved Issue #34 test execution plan.

--- a/.runs/postgres-schema/issue-34/07-qa-review.md
+++ b/.runs/postgres-schema/issue-34/07-qa-review.md
@@ -1,0 +1,26 @@
+# QA Review: Issue #34
+
+## Result
+
+Pass.
+
+## Findings
+
+- None. The approved diff is limited to `sql/schema.sql`, and the final schema matches Issue #34 acceptance criteria for required columns, `(source_site, source_listing_id)` uniqueness, `auction_end_date DATE`, `sale_price INTEGER NOT NULL`, `listing_details_raw JSONB`, low-risk checks, and indexes on `auction_end_date` and non-null `vin`.
+
+## Open Questions / Assumptions
+
+- Assumption: the future persistence layer will map transformed BAT output field `listing_id` to schema field `source_listing_id`, since insert/upsert code is explicitly out of scope for Issue #34.
+
+## Test Gaps
+
+- Automated schema tests were not added or run. This is consistent with the approved test execution plan and is deferred to Issue #36.
+- PostgreSQL DDL execution was not run, so verification is review-only.
+
+## Scope Drift
+
+- None found. The change stays within schema columns, source uniqueness, constraints, and indexes, and does not add insert/upsert code, Docker/bootstrap wiring, automated tests, or raw HTML database storage.
+
+## Residual Risk
+
+- Review-only verification may miss PostgreSQL execution issues until Issue #36 adds automated schema checks or the schema is applied in a real database.

--- a/.runs/postgres-schema/issue-34/08-final-change-summary.md
+++ b/.runs/postgres-schema/issue-34/08-final-change-summary.md
@@ -1,0 +1,67 @@
+# Final Change Summary: Issue #34
+
+## Issue
+
+#34: Define MVP listings table schema
+
+## Files Changed
+
+- `sql/schema.sql`
+- `.runs/postgres-schema/issue-34/00-issue.md`
+- `.runs/postgres-schema/issue-34/01-execution-plan.md`
+- `.runs/postgres-schema/issue-34/02-change-summary.md`
+- `.runs/postgres-schema/issue-34/03-change-diff.patch`
+- `.runs/postgres-schema/issue-34/04-test-execution-plan.md`
+- `.runs/postgres-schema/issue-34/05-test-diff.patch`
+- `.runs/postgres-schema/issue-34/06-verification-log.md`
+- `.runs/postgres-schema/issue-34/07-qa-review.md`
+- `.runs/postgres-schema/issue-34/08-final-change-summary.md`
+
+## Summary
+
+- Updated `sql/schema.sql` to define the MVP canonical `listings` table for transformed Bring a Trailer listings.
+- Replaced the minimal `raw_url` and `title` shape with `url`, `make`, `model`, `year`, `mileage`, `vin`, `sale_price`, `sold`, `auction_end_date`, `transmission`, and `listing_details_raw`.
+- Preserved uniqueness on `(source_site, source_listing_id)`.
+- Added low-risk constraints for `year`, `mileage`, `sale_price`, and `transmission`.
+- Added indexes for `auction_end_date` and non-null `vin` values.
+- Kept insert/upsert code, Docker initialization wiring, automated schema verification tests, and raw HTML database storage out of scope.
+
+## Verification
+
+- Review-only verification passed.
+- No automated tests were added or run because schema verification tests are deferred to issue #36.
+- QA review passed with no findings.
+
+## Residual Risk
+
+- PostgreSQL DDL execution has not been run in this issue. That risk is accepted for issue #34 and should be covered by the follow-up schema verification issue.
+
+## Draft Commit Message
+
+Define MVP listings schema
+
+## Draft PR Title
+
+Define MVP listings schema
+
+## Draft PR Body
+
+```markdown
+## Summary
+
+- define the MVP canonical `listings` table for transformed Bring a Trailer listings
+- add vehicle, sale, auction date, transmission, and source detail columns
+- preserve source listing uniqueness and add basic checks plus lookup indexes
+
+## Verification
+
+- Review-only verification passed against `sql/schema.sql`
+- QA review passed with no findings
+- Automated schema tests were not added or run because issue #36 covers schema verification checks
+
+Closes #34
+```
+
+## Stop Point
+
+Await explicit user approval before committing, pushing, or opening a pull request.

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS listings (
+    id BIGSERIAL PRIMARY KEY,
+    source_site TEXT NOT NULL,
+    source_listing_id TEXT NOT NULL,
+    url TEXT NOT NULL,
+    make TEXT NOT NULL,
+    model TEXT NOT NULL,
+    year INTEGER NOT NULL,
+    mileage INTEGER,
+    vin TEXT,
+    sale_price INTEGER NOT NULL,
+    sold BOOLEAN NOT NULL,
+    auction_end_date DATE NOT NULL,
+    transmission TEXT,
+    listing_details_raw JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (source_site, source_listing_id),
+    CONSTRAINT listings_year_check CHECK (year >= 1886 AND year <= 2100),
+    CONSTRAINT listings_mileage_check CHECK (mileage IS NULL OR mileage >= 0),
+    CONSTRAINT listings_sale_price_check CHECK (sale_price >= 0),
+    CONSTRAINT listings_transmission_check CHECK (transmission IS NULL OR transmission IN ('manual', 'automatic'))
+);
+
+CREATE INDEX IF NOT EXISTS listings_auction_end_date_idx
+    ON listings (auction_end_date);
+
+CREATE INDEX IF NOT EXISTS listings_vin_idx
+    ON listings (vin)
+    WHERE vin IS NOT NULL;


### PR DESCRIPTION
## Summary

- define the MVP canonical `listings` table for transformed Bring a Trailer listings
- add vehicle, sale, auction date, transmission, and source detail columns
- preserve source listing uniqueness and add basic checks plus lookup indexes

## Verification

- Review-only verification passed against `sql/schema.sql`
- QA review passed with no findings
- Automated schema tests were not added or run because issue #36 covers schema verification checks

Closes #34