### PR TITLE
Store raw BAT HTML in Postgres

### DIFF
--- a/app/sources/bat/ingest.py
+++ b/app/sources/bat/ingest.py
@@ -1,9 +1,30 @@
-from pathlib import Path
+import os
 
+import psycopg
 import requests
 
 
-RAW_HTML_DIR = Path(__file__).resolve().parents[3] / "data" / "raw" / "bat"
+SOURCE_SITE = "bringatrailer"
+
+UPSERT_RAW_LISTING_HTML_SQL = """
+INSERT INTO raw_listing_html (
+    source_site,
+    source_listing_id,
+    url,
+    raw_html,
+    processed
+) VALUES (
+    %(source_site)s,
+    %(source_listing_id)s,
+    %(url)s,
+    %(raw_html)s,
+    FALSE
+)
+ON CONFLICT (source_site, source_listing_id) DO UPDATE SET
+    url = EXCLUDED.url,
+    raw_html = EXCLUDED.raw_html,
+    processed = FALSE
+"""
 
 
 def fetch_listing_html(id):
@@ -13,8 +34,22 @@ def fetch_listing_html(id):
     return response.text
 
 
-def save_listing_html(listing_id, html):
-    RAW_HTML_DIR.mkdir(parents=True, exist_ok=True)
-    file_path = RAW_HTML_DIR / f"{listing_id}.html"
-    file_path.write_text(html, encoding="utf-8", newline="")
-    return file_path
+def save_listing_html(listing_id, html, url=None):
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set")
+
+    params = build_raw_listing_html_params(listing_id, html, url)
+
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(UPSERT_RAW_LISTING_HTML_SQL, params)
+
+
+def build_raw_listing_html_params(listing_id, html, url=None):
+    return {
+        "source_site": SOURCE_SITE,
+        "source_listing_id": listing_id,
+        "url": url or f"https://bringatrailer.com/listing/{listing_id}/",
+        "raw_html": html,
+    }

--- a/app/sources/bat/load.py
+++ b/app/sources/bat/load.py
@@ -49,6 +49,13 @@ ON CONFLICT (source_site, source_listing_id) DO UPDATE SET
     updated_at = NOW()
 """
 
+MARK_RAW_LISTING_PROCESSED_SQL = """
+UPDATE raw_listing_html
+SET processed = TRUE
+WHERE source_site = %(source_site)s
+  AND source_listing_id = %(source_listing_id)s
+"""
+
 
 def load_listing(transformed_listing):
     database_url = os.environ.get("DATABASE_URL")
@@ -59,6 +66,7 @@ def load_listing(transformed_listing):
     with psycopg.connect(database_url) as conn:
         with conn.cursor() as cur:
             cur.execute(INSERT_LISTING_SQL, params)
+            cur.execute(MARK_RAW_LISTING_PROCESSED_SQL, params)
 
 
 def build_listing_params(transformed_listing):

--- a/app/sources/bat/transform.py
+++ b/app/sources/bat/transform.py
@@ -1,19 +1,45 @@
 import json
+import os
 import re
 from datetime import datetime
-from pathlib import Path
 from bs4 import BeautifulSoup
+import psycopg
 
-RAW_HTML_DIR = Path(__file__).resolve().parents[3] / "data" / "raw" / "bat"
-TRANSFORMED_HTML_DIR = Path(__file__).resolve().parents[3] / "data" / "transformed" / "bat"
 
 SOURCE_SITE = "bringatrailer"
 
+SELECT_RAW_LISTING_HTML_SQL = """
+SELECT raw_html
+FROM raw_listing_html
+WHERE source_site = %(source_site)s
+  AND source_listing_id = %(source_listing_id)s
+"""
+
+
 def load_listing_html(listing_id):
-    file_path = RAW_HTML_DIR / f"{listing_id}.html"
-    if not file_path.exists():
-        raise FileNotFoundError(f"Raw HTML file not found for listing ID: {listing_id}")
-    return file_path.read_text(encoding="utf-8")
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set")
+
+    params = build_raw_listing_lookup_params(listing_id)
+
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(SELECT_RAW_LISTING_HTML_SQL, params)
+            row = cur.fetchone()
+
+    if row is None:
+        raise LookupError(f"Raw HTML record not found for listing ID: {listing_id}")
+
+    return row[0]
+
+
+def build_raw_listing_lookup_params(listing_id):
+    return {
+        "source_site": SOURCE_SITE,
+        "source_listing_id": listing_id,
+    }
+
 
 def transform_listing_html(listing_id):
     html = load_listing_html(listing_id)
@@ -50,12 +76,6 @@ def transform_listing_html(listing_id):
         "listing_details_raw": listing_details,
     }
     return transformed_data
-
-def store_transformed_data(listing_id, data):
-    file_path = TRANSFORMED_HTML_DIR / f"{listing_id}.json"
-    file_path.parent.mkdir(parents=True, exist_ok=True)
-    file_path.write_text(json.dumps(data, default=str, indent=2), encoding="utf-8")
-    return file_path
 
 def get_product_json_ld(soup):
     for script_tag in soup.find_all("script", attrs={"type": "application/ld+json"}):

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -22,3 +22,13 @@ CREATE TABLE IF NOT EXISTS listings (
     CONSTRAINT listings_transmission_check CHECK (transmission IS NULL OR transmission IN ('manual', 'automatic'))
 );
 
+CREATE TABLE IF NOT EXISTS raw_listing_html (
+    id BIGSERIAL PRIMARY KEY,
+    source_site TEXT NOT NULL,
+    source_listing_id TEXT NOT NULL,
+    url TEXT NOT NULL,
+    raw_html TEXT NOT NULL,
+    processed BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (source_site, source_listing_id)
+)

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS raw_listing_html (
     source_listing_id TEXT NOT NULL,
     url TEXT NOT NULL,
     raw_html TEXT NOT NULL,
-    processed BOOLEAN NOT NULL DEFAULT FALSE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    processed BOOLEAN NOT NULL DEFAULT FALSE,
     UNIQUE (source_site, source_listing_id)
-)
+);

--- a/tests/integration/bat/test_ingest_integration.py
+++ b/tests/integration/bat/test_ingest_integration.py
@@ -1,21 +1,156 @@
-from app.sources.bat.ingest import fetch_listing_html, save_listing_html
+import subprocess
+import time
+import uuid
+from pathlib import Path
 
-def test_fetch_listing_html_live():
-    # Fetch a real BAT listing and verify that HTML is returned.
-    html = fetch_listing_html("2004-bmw-m3-coupe-232")
-    assert isinstance(html, str)
-    assert len(html) > 0
-    assert "<html" in html.lower()
+import psycopg
+import pytest
+
+from app.sources.bat.ingest import save_listing_html
 
 
-def test_save_listing_html_live(tmp_path, mocker):
-    # Redirect raw storage into pytest's temp directory for this live save test.
-    mocker.patch("app.sources.bat.ingest.RAW_HTML_DIR", tmp_path / "data" / "raw" / "bat")
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = REPO_ROOT / "sql" / "schema.sql"
 
-    # Fetch live HTML, persist it locally, and verify that a non-empty HTML file was created.
-    html = fetch_listing_html("2004-bmw-m3-coupe-232")
-    saved_path = save_listing_html("2004-bmw-m3-coupe-232", html)
 
-    assert saved_path.exists()
-    assert saved_path.suffix == ".html"
-    assert saved_path.stat().st_size > 0
+def test_save_listing_html_upserts_raw_html_in_postgres_container(monkeypatch):
+    if not _docker_daemon_available():
+        pytest.skip("Docker daemon is not available")
+
+    container_name = f"auction-ingest-test-{uuid.uuid4().hex}"
+    schema_mount = f"{SCHEMA_PATH}:/docker-entrypoint-initdb.d/001-schema.sql:ro"
+
+    try:
+        _run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "-d",
+                "--name",
+                container_name,
+                "-e",
+                "POSTGRES_DB=auction_etl",
+                "-e",
+                "POSTGRES_USER=auction_user",
+                "-e",
+                "POSTGRES_PASSWORD=localdevpassword",
+                "-p",
+                "127.0.0.1::5432",
+                "-v",
+                schema_mount,
+                "postgres:17",
+            ]
+        )
+        _wait_for_postgres(container_name)
+
+        port = _host_port(container_name)
+        database_url = (
+            f"postgresql://auction_user:localdevpassword@127.0.0.1:{port}/auction_etl"
+        )
+        _wait_for_database_url(database_url)
+        monkeypatch.setenv("DATABASE_URL", database_url)
+
+        save_listing_html(
+            "test-listing",
+            "<html>First</html>",
+            "https://example.test/first",
+        )
+        with psycopg.connect(database_url) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE raw_listing_html
+                    SET processed = TRUE
+                    WHERE source_site = %s AND source_listing_id = %s
+                    """,
+                    ("bringatrailer", "test-listing"),
+                )
+
+        save_listing_html(
+            "test-listing",
+            "<html>Second</html>",
+            "https://example.test/second",
+        )
+
+        with psycopg.connect(database_url) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT COUNT(*), MAX(url), MAX(raw_html), bool_or(processed)
+                    FROM raw_listing_html
+                    WHERE source_site = %s AND source_listing_id = %s
+                    """,
+                    ("bringatrailer", "test-listing"),
+                )
+                row_count, url, raw_html, processed = cur.fetchone()
+
+        assert row_count == 1
+        assert url == "https://example.test/second"
+        assert raw_html == "<html>Second</html>"
+        assert processed is False
+    finally:
+        subprocess.run(["docker", "rm", "-f", container_name], capture_output=True, text=True)
+
+
+def _docker_daemon_available():
+    try:
+        result = subprocess.run(["docker", "info"], capture_output=True, text=True)
+    except FileNotFoundError:
+        return False
+    return result.returncode == 0
+
+
+def _wait_for_postgres(container_name):
+    deadline = time.monotonic() + 30
+    last_error = ""
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            [
+                "docker",
+                "exec",
+                container_name,
+                "psql",
+                "-U",
+                "auction_user",
+                "-d",
+                "auction_etl",
+                "-t",
+                "-A",
+                "-c",
+                "SELECT 1;",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return
+        last_error = result.stderr or result.stdout
+        time.sleep(1)
+
+    pytest.fail(f"Postgres did not become ready: {last_error}")
+
+
+def _host_port(container_name):
+    result = _run(["docker", "port", container_name, "5432/tcp"])
+    return result.stdout.rsplit(":", maxsplit=1)[-1].strip()
+
+
+def _wait_for_database_url(database_url):
+    deadline = time.monotonic() + 30
+    last_error = ""
+    while time.monotonic() < deadline:
+        try:
+            with psycopg.connect(database_url) as conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT 1;")
+            return
+        except psycopg.OperationalError as exc:
+            last_error = str(exc)
+            time.sleep(1)
+
+    pytest.fail(f"Postgres host connection did not become ready: {last_error}")
+
+
+def _run(command):
+    return subprocess.run(command, capture_output=True, text=True, check=True)

--- a/tests/integration/bat/test_load_integration.py
+++ b/tests/integration/bat/test_load_integration.py
@@ -54,7 +54,34 @@ def test_load_listing_upserts_into_postgres_container(monkeypatch):
         database_url = (
             f"postgresql://auction_user:localdevpassword@127.0.0.1:{port}/auction_etl"
         )
+        _wait_for_database_url(database_url)
         monkeypatch.setenv("DATABASE_URL", database_url)
+
+        with psycopg.connect(database_url) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO raw_listing_html (
+                        source_site,
+                        source_listing_id,
+                        url,
+                        raw_html,
+                        processed
+                    ) VALUES (
+                        %s,
+                        %s,
+                        %s,
+                        %s,
+                        FALSE
+                    )
+                    """,
+                    (
+                        "bringatrailer",
+                        "test-listing",
+                        "https://bringatrailer.com/listing/test-listing/",
+                        "<html>Raw</html>",
+                    ),
+                )
 
         listing = _transformed_listing(sale_price=19750, details=["Original detail"])
         load_listing(listing)
@@ -85,10 +112,20 @@ def test_load_listing_upserts_into_postgres_container(monkeypatch):
                     ("bringatrailer", "test-listing"),
                 )
                 (listing_details_raw,) = cur.fetchone()
+                cur.execute(
+                    """
+                    SELECT processed
+                    FROM raw_listing_html
+                    WHERE source_site = %s AND source_listing_id = %s
+                    """,
+                    ("bringatrailer", "test-listing"),
+                )
+                (raw_processed,) = cur.fetchone()
 
         assert row_count == 1
         assert sale_price == 20500
         assert listing_details_raw == ["Updated detail", "6-Speed Manual Transmission"]
+        assert raw_processed is True
     finally:
         subprocess.run(["docker", "rm", "-f", container_name], capture_output=True, text=True)
 
@@ -152,6 +189,22 @@ def _wait_for_postgres(container_name):
 def _host_port(container_name):
     result = _run(["docker", "port", container_name, "5432/tcp"])
     return result.stdout.rsplit(":", maxsplit=1)[-1].strip()
+
+
+def _wait_for_database_url(database_url):
+    deadline = time.monotonic() + 30
+    last_error = ""
+    while time.monotonic() < deadline:
+        try:
+            with psycopg.connect(database_url) as conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT 1;")
+            return
+        except psycopg.OperationalError as exc:
+            last_error = str(exc)
+            time.sleep(1)
+
+    pytest.fail(f"Postgres host connection did not become ready: {last_error}")
 
 
 def _run(command):

--- a/tests/integration/bat/test_transform_integration.py
+++ b/tests/integration/bat/test_transform_integration.py
@@ -1,14 +1,18 @@
-import json
-import shutil
+import subprocess
+import time
+import uuid
 from pathlib import Path
 
+import psycopg
 import pytest
 
-from app.sources.bat.transform import store_transformed_data, transform_listing_html
+from app.sources.bat.transform import transform_listing_html
 
 
 LISTING_ID = "2004-bmw-m3-coupe-232"
-FIXTURE_PATH = Path(__file__).resolve().parents[3] / "data" / "raw" / "bat" / f"{LISTING_ID}.html"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = REPO_ROOT / "sql" / "schema.sql"
+FIXTURE_PATH = REPO_ROOT / "data" / "raw" / "bat" / f"{LISTING_ID}.html"
 
 EXPECTED_TRANSFORMED_DATA = {
     "source_site": "bringatrailer",
@@ -45,47 +49,183 @@ EXPECTED_TRANSFORMED_DATA = {
 }
 
 
-def test_transform_listing_html_and_store_transformed_data_with_real_fixture(tmp_path, mocker):
-    raw_dir = tmp_path / "data" / "raw" / "bat"
-    transformed_dir = tmp_path / "data" / "transformed" / "bat"
-    raw_dir.mkdir(parents=True)
-    shutil.copyfile(FIXTURE_PATH, raw_dir / f"{LISTING_ID}.html")
+def test_transform_listing_html_reads_raw_html_from_postgres_container(
+    monkeypatch,
+):
+    if not _docker_daemon_available():
+        pytest.skip("Docker daemon is not available")
 
-    mocker.patch("app.sources.bat.transform.RAW_HTML_DIR", raw_dir)
-    mocker.patch("app.sources.bat.transform.TRANSFORMED_HTML_DIR", transformed_dir)
+    container_name = f"auction-transform-test-{uuid.uuid4().hex}"
+    schema_mount = f"{SCHEMA_PATH}:/docker-entrypoint-initdb.d/001-schema.sql:ro"
 
-    transformed_data = transform_listing_html(LISTING_ID)
-    assert transformed_data == EXPECTED_TRANSFORMED_DATA
+    try:
+        _run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "-d",
+                "--name",
+                container_name,
+                "-e",
+                "POSTGRES_DB=auction_etl",
+                "-e",
+                "POSTGRES_USER=auction_user",
+                "-e",
+                "POSTGRES_PASSWORD=localdevpassword",
+                "-p",
+                "127.0.0.1::5432",
+                "-v",
+                schema_mount,
+                "postgres:17",
+            ]
+        )
+        _wait_for_postgres(container_name)
 
-    saved_path = store_transformed_data(LISTING_ID, transformed_data)
+        port = _host_port(container_name)
+        database_url = (
+            f"postgresql://auction_user:localdevpassword@127.0.0.1:{port}/auction_etl"
+        )
+        _wait_for_database_url(database_url)
+        monkeypatch.setenv("DATABASE_URL", database_url)
+        _insert_raw_html(database_url, LISTING_ID, FIXTURE_PATH.read_text(encoding="utf-8"))
 
-    assert saved_path == transformed_dir / f"{LISTING_ID}.json"
-    assert json.loads(saved_path.read_text(encoding="utf-8")) == EXPECTED_TRANSFORMED_DATA
-
-
-def test_store_transformed_data_overwrites_existing_transformed_fixture(tmp_path, mocker):
-    transformed_dir = tmp_path / "data" / "transformed" / "bat"
-    existing_path = transformed_dir / f"{LISTING_ID}.json"
-    existing_path.parent.mkdir(parents=True)
-    existing_path.write_text(json.dumps({"listing_id": LISTING_ID, "stale": True}), encoding="utf-8")
-
-    mocker.patch("app.sources.bat.transform.TRANSFORMED_HTML_DIR", transformed_dir)
-
-    saved_path = store_transformed_data(LISTING_ID, EXPECTED_TRANSFORMED_DATA)
-
-    assert saved_path == existing_path
-    assert json.loads(saved_path.read_text(encoding="utf-8")) == EXPECTED_TRANSFORMED_DATA
+        transformed_data = transform_listing_html(LISTING_ID)
+        assert transformed_data == EXPECTED_TRANSFORMED_DATA
+    finally:
+        subprocess.run(["docker", "rm", "-f", container_name], capture_output=True, text=True)
 
 
-def test_transform_listing_html_missing_raw_fixture_does_not_write_output(tmp_path, mocker):
-    raw_dir = tmp_path / "data" / "raw" / "bat"
-    transformed_dir = tmp_path / "data" / "transformed" / "bat"
-    raw_dir.mkdir(parents=True)
+def test_transform_listing_html_missing_raw_record_raises_clear_error(
+    monkeypatch,
+):
+    if not _docker_daemon_available():
+        pytest.skip("Docker daemon is not available")
 
-    mocker.patch("app.sources.bat.transform.RAW_HTML_DIR", raw_dir)
-    mocker.patch("app.sources.bat.transform.TRANSFORMED_HTML_DIR", transformed_dir)
+    container_name = f"auction-transform-missing-test-{uuid.uuid4().hex}"
+    schema_mount = f"{SCHEMA_PATH}:/docker-entrypoint-initdb.d/001-schema.sql:ro"
 
-    with pytest.raises(FileNotFoundError, match="Raw HTML file not found for listing ID: missing-listing"):
-        transform_listing_html("missing-listing")
+    try:
+        _run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "-d",
+                "--name",
+                container_name,
+                "-e",
+                "POSTGRES_DB=auction_etl",
+                "-e",
+                "POSTGRES_USER=auction_user",
+                "-e",
+                "POSTGRES_PASSWORD=localdevpassword",
+                "-p",
+                "127.0.0.1::5432",
+                "-v",
+                schema_mount,
+                "postgres:17",
+            ]
+        )
+        _wait_for_postgres(container_name)
 
-    assert not (transformed_dir / "missing-listing.json").exists()
+        port = _host_port(container_name)
+        database_url = (
+            f"postgresql://auction_user:localdevpassword@127.0.0.1:{port}/auction_etl"
+        )
+        _wait_for_database_url(database_url)
+        monkeypatch.setenv("DATABASE_URL", database_url)
+
+        with pytest.raises(LookupError, match="Raw HTML record not found for listing ID: missing-listing"):
+            transform_listing_html("missing-listing")
+    finally:
+        subprocess.run(["docker", "rm", "-f", container_name], capture_output=True, text=True)
+
+
+def _insert_raw_html(database_url, listing_id, raw_html):
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO raw_listing_html (
+                    source_site,
+                    source_listing_id,
+                    url,
+                    raw_html
+                ) VALUES (
+                    %s,
+                    %s,
+                    %s,
+                    %s
+                )
+                """,
+                (
+                    "bringatrailer",
+                    listing_id,
+                    f"https://bringatrailer.com/listing/{listing_id}/",
+                    raw_html,
+                ),
+            )
+
+
+def _docker_daemon_available():
+    try:
+        result = subprocess.run(["docker", "info"], capture_output=True, text=True)
+    except FileNotFoundError:
+        return False
+    return result.returncode == 0
+
+
+def _wait_for_postgres(container_name):
+    deadline = time.monotonic() + 30
+    last_error = ""
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            [
+                "docker",
+                "exec",
+                container_name,
+                "psql",
+                "-U",
+                "auction_user",
+                "-d",
+                "auction_etl",
+                "-t",
+                "-A",
+                "-c",
+                "SELECT 1;",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return
+        last_error = result.stderr or result.stdout
+        time.sleep(1)
+
+    pytest.fail(f"Postgres did not become ready: {last_error}")
+
+
+def _host_port(container_name):
+    result = _run(["docker", "port", container_name, "5432/tcp"])
+    return result.stdout.rsplit(":", maxsplit=1)[-1].strip()
+
+
+def _wait_for_database_url(database_url):
+    deadline = time.monotonic() + 30
+    last_error = ""
+    while time.monotonic() < deadline:
+        try:
+            with psycopg.connect(database_url) as conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT 1;")
+            return
+        except psycopg.OperationalError as exc:
+            last_error = str(exc)
+            time.sleep(1)
+
+    pytest.fail(f"Postgres host connection did not become ready: {last_error}")
+
+
+def _run(command):
+    return subprocess.run(command, capture_output=True, text=True, check=True)

--- a/tests/integration/test_postgres_schema.py
+++ b/tests/integration/test_postgres_schema.py
@@ -70,6 +70,71 @@ def test_schema_sql_applies_in_isolated_postgres_container():
             """,
         )
         assert "source_site,source_listing_id" in unique_columns
+
+        raw_column_rows = _psql(
+            container_name,
+            """
+            SELECT column_name || ':' || data_type || ':' || is_nullable
+            FROM information_schema.columns
+            WHERE table_name = 'raw_listing_html'
+              AND column_name IN (
+                  'id',
+                  'source_site',
+                  'source_listing_id',
+                  'url',
+                  'raw_html',
+                  'created_at',
+                  'processed'
+              )
+            ORDER BY column_name;
+            """,
+        )
+        assert raw_column_rows == [
+            "created_at:timestamp with time zone:NO",
+            "id:bigint:NO",
+            "processed:boolean:NO",
+            "raw_html:text:NO",
+            "source_listing_id:text:NO",
+            "source_site:text:NO",
+            "url:text:NO",
+        ]
+
+        raw_unique_columns = _psql(
+            container_name,
+            """
+            SELECT string_agg(a.attname, ',' ORDER BY array_position(c.conkey, a.attnum))
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(c.conkey)
+            WHERE t.relname = 'raw_listing_html'
+              AND c.contype = 'u'
+            GROUP BY c.oid;
+            """,
+        )
+        assert "source_site,source_listing_id" in raw_unique_columns
+
+        raw_defaults = _psql(
+            container_name,
+            """
+            WITH inserted AS (
+                INSERT INTO raw_listing_html (
+                    source_site,
+                    source_listing_id,
+                    url,
+                    raw_html
+                ) VALUES (
+                    'bringatrailer',
+                    'schema-test',
+                    'https://example.test/schema-test',
+                    '<html>schema</html>'
+                )
+                RETURNING processed, created_at
+            )
+            SELECT processed::text, created_at IS NOT NULL
+            FROM inserted;
+            """,
+        )
+        assert raw_defaults == ["false|t"]
     finally:
         subprocess.run(["docker", "rm", "-f", container_name], capture_output=True, text=True)
 

--- a/tests/unit/bat/test_ingest.py
+++ b/tests/unit/bat/test_ingest.py
@@ -1,5 +1,6 @@
 import pytest
 import requests
+from app.sources.bat import ingest
 from app.sources.bat.ingest import fetch_listing_html, save_listing_html
 
 # test that the function returns the correct HTML and that the request is made with the correct URL
@@ -40,27 +41,80 @@ def test_fetch_listing_html_connection_error(mocker):
         fetch_listing_html("test-id")
 
 
-def test_save_listing_html_writes_file_and_returns_path(tmp_path, mocker):
-    # redirect raw HTML storage into pytest's temporary directory
-    mocker.patch("app.sources.bat.ingest.RAW_HTML_DIR", tmp_path / "data" / "raw" / "bat")
+def test_build_raw_listing_html_params_maps_listing_to_schema_columns():
+    params = ingest.build_raw_listing_html_params(
+        "test-id",
+        "<html>Test</html>",
+        "https://example.test/listing/test-id",
+    )
 
-    # save test HTML and capture the returned file path
-    saved_path = save_listing_html("test-id", "<html>Test</html>")
+    assert params == {
+        "source_site": "bringatrailer",
+        "source_listing_id": "test-id",
+        "url": "https://example.test/listing/test-id",
+        "raw_html": "<html>Test</html>",
+    }
 
-    # assert that the file was written to the expected location with the expected contents
-    assert saved_path == tmp_path / "data" / "raw" / "bat" / "test-id.html"
-    assert saved_path.exists()
-    assert saved_path.read_text(encoding="utf-8") == "<html>Test</html>"
+
+def test_build_raw_listing_html_params_defaults_bat_url():
+    params = ingest.build_raw_listing_html_params("test-id", "<html>Test</html>")
+
+    assert params["url"] == "https://bringatrailer.com/listing/test-id/"
 
 
-def test_save_listing_html_overwrites_existing_file(tmp_path, mocker):
-    # redirect raw HTML storage into pytest's temporary directory
-    mocker.patch("app.sources.bat.ingest.RAW_HTML_DIR", tmp_path / "data" / "raw" / "bat")
+def test_save_listing_html_executes_upsert_with_expected_conflict_target(mocker):
+    calls = {}
 
-    # save the same listing twice to verify that the second write overwrites the first
-    first_path = save_listing_html("test-id", "<html>First</html>")
-    second_path = save_listing_html("test-id", "<html>Second</html>")
+    class FakeCursor:
+        def __enter__(self):
+            return self
 
-    # assert that both saves point to the same file and that the latest contents were written
-    assert first_path == second_path
-    assert second_path.read_text(encoding="utf-8") == "<html>Second</html>"
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            calls["sql"] = sql
+            calls["params"] = params
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+    def fake_connect(database_url):
+        calls["database_url"] = database_url
+        return FakeConnection()
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    mocker.patch.object(ingest.psycopg, "connect", side_effect=fake_connect)
+
+    save_listing_html(
+        "test-id",
+        "<html>Test</html>",
+        "https://example.test/listing/test-id",
+    )
+
+    assert calls["database_url"] == "postgresql://user:pass@localhost/db"
+    assert "ON CONFLICT (source_site, source_listing_id) DO UPDATE" in calls["sql"]
+    assert "processed = FALSE" in calls["sql"]
+    assert calls["params"] == {
+        "source_site": "bringatrailer",
+        "source_listing_id": "test-id",
+        "url": "https://example.test/listing/test-id",
+        "raw_html": "<html>Test</html>",
+    }
+
+
+def test_save_listing_html_requires_database_url(mocker):
+    mocker.patch.dict("os.environ", {}, clear=True)
+
+    with pytest.raises(RuntimeError, match="DATABASE_URL must be set"):
+        save_listing_html("test-id", "<html>Test</html>")

--- a/tests/unit/bat/test_load.py
+++ b/tests/unit/bat/test_load.py
@@ -26,7 +26,7 @@ def test_build_listing_params_maps_transformed_listing_to_schema_columns():
 
 
 def test_load_listing_executes_upsert_with_expected_conflict_target(mocker):
-    calls = {}
+    calls = {"executions": []}
 
     class FakeCursor:
         def __enter__(self):
@@ -36,8 +36,7 @@ def test_load_listing_executes_upsert_with_expected_conflict_target(mocker):
             return False
 
         def execute(self, sql, params):
-            calls["sql"] = sql
-            calls["params"] = params
+            calls["executions"].append((sql, params))
 
     class FakeConnection:
         def __enter__(self):
@@ -61,15 +60,23 @@ def test_load_listing_executes_upsert_with_expected_conflict_target(mocker):
 
     load.load_listing(_transformed_listing())
 
+    listing_sql, listing_params = calls["executions"][0]
+    processed_sql, processed_params = calls["executions"][1]
+
     assert calls["database_url"] == "postgresql://user:pass@localhost/db"
-    assert "ON CONFLICT (source_site, source_listing_id) DO UPDATE" in calls["sql"]
-    assert "updated_at = NOW()" in calls["sql"]
-    assert calls["params"]["source_listing_id"] == "test-listing"
-    assert calls["params"]["listing_details_raw"].obj == [
+    assert "ON CONFLICT (source_site, source_listing_id) DO UPDATE" in listing_sql
+    assert "updated_at = NOW()" in listing_sql
+    assert listing_params["source_listing_id"] == "test-listing"
+    assert listing_params["listing_details_raw"].obj == [
         "Chassis: WBSBL93414PN57203",
         "50,250 Miles",
         "6-Speed Manual Transmission",
     ]
+    assert "UPDATE raw_listing_html" in processed_sql
+    assert "SET processed = TRUE" in processed_sql
+    assert "source_site = %(source_site)s" in processed_sql
+    assert "source_listing_id = %(source_listing_id)s" in processed_sql
+    assert processed_params is listing_params
 
 
 def test_load_listing_requires_database_url(mocker):

--- a/tests/unit/bat/test_transform.py
+++ b/tests/unit/bat/test_transform.py
@@ -1,7 +1,7 @@
-import json
 from bs4 import BeautifulSoup
 import pytest
 
+from app.sources.bat import transform
 from app.sources.bat.transform import (
     extract_auction_end_date,
     extract_group_value,
@@ -18,82 +18,107 @@ from app.sources.bat.transform import (
     parse_mileage,
     parse_model,
     parse_year,
-    store_transformed_data,
     transform_listing_html,
 )
 
-def test_load_listing_html(tmp_path, mocker):
-    # redirect raw HTML storage into pytest's temporary directory
-    mocker.patch("app.sources.bat.transform.RAW_HTML_DIR", tmp_path / "data" / "raw" / "bat")
+def test_build_raw_listing_lookup_params_maps_listing_to_schema_columns():
+    params = transform.build_raw_listing_lookup_params("test-id")
 
-    # create a test HTML file to load
-    test_file = tmp_path / "data" / "raw" / "bat" / "test-id.html"
-    test_file.parent.mkdir(parents=True, exist_ok=True)
-    test_file.write_text("<html>Test</html>", encoding="utf-8")
+    assert params == {
+        "source_site": "bringatrailer",
+        "source_listing_id": "test-id",
+    }
 
-    # call the function being tested and assert that the loaded HTML is correct
+
+def test_load_listing_html_retrieves_raw_html_from_postgres(mocker):
+    calls = {}
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            calls["sql"] = sql
+            calls["params"] = params
+
+        def fetchone(self):
+            return ("<html>Test</html>",)
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+    def fake_connect(database_url):
+        calls["database_url"] = database_url
+        return FakeConnection()
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    mocker.patch.object(transform.psycopg, "connect", side_effect=fake_connect)
+
     html = load_listing_html("test-id")
+
     assert html == "<html>Test</html>"
+    assert calls["database_url"] == "postgresql://user:pass@localhost/db"
+    assert "FROM raw_listing_html" in calls["sql"]
+    assert "source_site = %(source_site)s" in calls["sql"]
+    assert "source_listing_id = %(source_listing_id)s" in calls["sql"]
+    assert calls["params"] == {
+        "source_site": "bringatrailer",
+        "source_listing_id": "test-id",
+    }
 
-def test_load_listing_html_file_not_found(tmp_path, mocker):
-    # redirect raw HTML storage into pytest's temporary directory
-    mocker.patch("app.sources.bat.transform.RAW_HTML_DIR", tmp_path / "data" / "raw" / "bat")
 
-    # assert that a FileNotFoundError is raised when the file does not exist
-    with pytest.raises(FileNotFoundError, match="Raw HTML file not found for listing ID: missing-id"):
+def test_load_listing_html_missing_record_raises_clear_error(mocker):
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            return None
+
+        def fetchone(self):
+            return None
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    mocker.patch.object(transform.psycopg, "connect", return_value=FakeConnection())
+
+    with pytest.raises(LookupError, match="Raw HTML record not found for listing ID: missing-id"):
         load_listing_html("missing-id")
 
-def test_store_transformed_data_writes_file(tmp_path, mocker):
-    # redirect transformed data storage into pytest's temporary directory
-    mocker.patch("app.sources.bat.transform.TRANSFORMED_HTML_DIR", tmp_path / "data" / "transformed" / "bat")
 
-    # create some test transformed data to store
-    test_data = {"key": "value"}
+def test_load_listing_html_requires_database_url(mocker):
+    mocker.patch.dict("os.environ", {}, clear=True)
 
-    # call the function being tested and assert that the file was written with the correct contents
-    saved_path = store_transformed_data("test-id", test_data)
-    assert saved_path == tmp_path / "data" / "transformed" / "bat" / "test-id.json"
-    assert saved_path.exists()
-    assert saved_path.read_text(encoding="utf-8") == json.dumps(test_data, default=str, indent=2)
-
-def test_store_transformed_data_overwrites_existing_file(tmp_path, mocker):
-    # redirect transformed data storage into pytest's temporary directory
-    mocker.patch("app.sources.bat.transform.TRANSFORMED_HTML_DIR", tmp_path / "data" / "transformed" / "bat")
-
-    # create some test transformed data to store
-    test_data_1 = {"key": "value1"}
-    test_data_2 = {"key": "value2"}
-
-    # store the first set of data and assert that it was written correctly
-    saved_path_1 = store_transformed_data("test-id", test_data_1)
-    assert saved_path_1 == tmp_path / "data" / "transformed" / "bat" / "test-id.json"
-    assert saved_path_1.exists()
-    assert saved_path_1.read_text(encoding="utf-8") == json.dumps(test_data_1, default=str, indent=2)
-    # store the second set of data and assert that it overwrote the first
-    saved_path_2 = store_transformed_data("test-id", test_data_2)
-    assert saved_path_2 == tmp_path / "data" / "transformed" / "bat" / "test-id.json"
-    assert saved_path_2.exists()
-    assert saved_path_2.read_text(encoding="utf-8") == json.dumps(test_data_2, default=str, indent=2)
-    
-def test_store_transformed_data_creates_parent_directory(tmp_path, mocker):
-    # create a nested target directory path that does not exist
-    target_dir = tmp_path / "nested" / "transformed" / "bat"
-    # redirect transformed data storage into pytest's temporary directory
-    mocker.patch("app.sources.bat.transform.TRANSFORMED_HTML_DIR", target_dir)
-
-    # assert that the target directory does not exist before calling the function
-    assert not target_dir.exists()
-
-    # create some test transformed data to store
-    test_data = {"key": "value"}
-
-    # call the function being tested and assert that the parent directory was created and the file was writte
-    saved_path = store_transformed_data("test-id", test_data)
-    assert target_dir.exists()
-    assert target_dir.is_dir()
-    assert saved_path == target_dir / "test-id.json"
-    assert saved_path.exists()
-    assert json.loads(saved_path.read_text(encoding="utf-8")) == {"key": "value"}
+    with pytest.raises(RuntimeError, match="DATABASE_URL must be set"):
+        load_listing_html("test-id")
 
 def test_get_product_json_ld_returns_product_data(tmp_path):
     # create a test HTML file with a valid JSON-LD script tag


### PR DESCRIPTION
## Summary

- Store BAT raw listing HTML in Postgres via `raw_listing_html` instead of local raw HTML files.
- Transform BAT listings from database-backed raw HTML records and raise a clear missing-record error when absent.
- Mark matching raw HTML rows `processed = TRUE` after successful listing load.
- Remove local transformed JSON storage logic and related tests.
- Add/update unit and integration coverage for schema, ingest upsert, transform lookup, loader processed updates, and Docker host-port readiness.

## Verification

- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_ingest.py tests\unit\bat\test_transform.py tests\unit\bat\test_load.py` -> `61 passed`
- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_ingest.py tests\unit\bat\test_transform.py tests\unit\bat\test_load.py tests\integration\test_postgres_schema.py tests\integration\bat\test_ingest_integration.py tests\integration\bat\test_transform_integration.py tests\integration\bat\test_load_integration.py` -> `61 passed, 5 skipped` in this environment because Docker is unavailable
- Docker-backed integration tests passed in local user testing after the host-side mapped-port readiness fix

## QA

- QA review passed with no confirmed bugs, regressions, missing tests, or scope drift.
- Accepted concern: direct `load_listing()` calls can still upsert `listings` without failing when no matching raw row exists, preserving loader compatibility.

Closes #42