### PR TITLE
[codex] Add a basic CLI entrypoint for the BAT ETL pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,21 @@ Implementation Steps:
 - [x] Pull raw html from a URL
 - [x] Store raw html in local folder
 - [x] Parse html for data outlined in schema
-- [ ] Basic CLI
+- [x] Basic CLI
 - [ ] Structured error handling
 - [x] Postgres/Docker for Postgres
 - [ ] Store data into Postgres
+
+## CLI
+Run the current Phase 1 Bring a Trailer ETL pipeline from the repository root:
+
+```powershell
+python -m app.cli <bat-listing-id>
+```
+
+The command fetches the listing HTML, saves the raw HTML record, transforms it,
+and loads the transformed listing into Postgres. `DATABASE_URL` must be set for
+the save, transform, and load steps.
 
 ## Data Model
 - source_site: string

--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -1,0 +1,2 @@
+from .main import main, run_pipeline
+

--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -1,0 +1,5 @@
+from app.cli.main import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/cli/bat.py
+++ b/app/cli/bat.py
@@ -1,0 +1,1 @@
+from app.cli.main import build_parser, ingest, load, main, run_pipeline, transform

--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -1,0 +1,28 @@
+import argparse
+
+from app.sources.bat import ingest, load, transform
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="python -m app.cli",
+        description="Run the BAT ETL pipeline for a single Phase 1 listing.",
+    )
+    parser.add_argument(
+        "listing_id",
+        help="Required Bring a Trailer listing ID, such as 2004-bmw-m3-123.",
+    )
+    return parser
+
+
+def run_pipeline(listing_id):
+    html = ingest.fetch_listing_html(listing_id)
+    ingest.save_listing_html(listing_id, html)
+    transformed_listing = transform.transform_listing_html(listing_id)
+    load.load_listing(transformed_listing)
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    run_pipeline(args.listing_id)
+    return 0

--- a/tests/unit/cli/test_bat_cli.py
+++ b/tests/unit/cli/test_bat_cli.py
@@ -1,0 +1,67 @@
+import pytest
+
+from app.cli import bat
+
+
+def test_parser_accepts_required_listing_id():
+    args = bat.build_parser().parse_args(["2004-bmw-m3-123"])
+
+    assert args.listing_id == "2004-bmw-m3-123"
+
+
+def test_help_prints_usage(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        bat.main(["--help"])
+
+    captured = capsys.readouterr()
+
+    assert exc_info.value.code == 0
+    assert "usage: python -m app.cli" in captured.out
+    assert "Run the BAT ETL pipeline" in captured.out
+    assert "listing_id" in captured.out
+
+
+def test_missing_listing_id_fails_with_clear_error(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        bat.main([])
+
+    captured = capsys.readouterr()
+
+    assert exc_info.value.code == 2
+    assert "the following arguments are required: listing_id" in captured.err
+
+
+def test_main_dispatches_pipeline_in_order(mocker):
+    calls = []
+
+    mocker.patch.object(
+        bat.ingest,
+        "fetch_listing_html",
+        side_effect=lambda listing_id: calls.append(("fetch", listing_id)) or "<html></html>",
+    )
+    mocker.patch.object(
+        bat.ingest,
+        "save_listing_html",
+        side_effect=lambda listing_id, html: calls.append(("save", listing_id, html)),
+    )
+    mocker.patch.object(
+        bat.transform,
+        "transform_listing_html",
+        side_effect=lambda listing_id: calls.append(("transform", listing_id))
+        or {"listing_id": listing_id},
+    )
+    mocker.patch.object(
+        bat.load,
+        "load_listing",
+        side_effect=lambda listing: calls.append(("load", listing)),
+    )
+
+    exit_code = bat.main(["2004-bmw-m3-123"])
+
+    assert exit_code == 0
+    assert calls == [
+        ("fetch", "2004-bmw-m3-123"),
+        ("save", "2004-bmw-m3-123", "<html></html>"),
+        ("transform", "2004-bmw-m3-123"),
+        ("load", {"listing_id": "2004-bmw-m3-123"}),
+    ]

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -1,0 +1,55 @@
+from importlib import import_module
+
+import pytest
+
+cli_main = import_module("app.cli.main")
+
+
+def test_build_parser_accepts_listing_id():
+    parser = cli_main.build_parser()
+
+    args = parser.parse_args(["2004-bmw-m3-coupe-232"])
+
+    assert args.listing_id == "2004-bmw-m3-coupe-232"
+
+
+def test_main_runs_bat_pipeline_in_order(mocker):
+    fetch_listing_html = mocker.patch(
+        "app.cli.main.ingest.fetch_listing_html",
+        return_value="<html>raw</html>",
+    )
+    save_listing_html = mocker.patch("app.cli.main.ingest.save_listing_html")
+    transform_listing_html = mocker.patch(
+        "app.cli.main.transform.transform_listing_html",
+        return_value={"listing_id": "2004-bmw-m3-coupe-232"},
+    )
+    load_listing = mocker.patch("app.cli.main.load.load_listing")
+
+    exit_code = cli_main.main(["2004-bmw-m3-coupe-232"])
+
+    assert exit_code == 0
+    fetch_listing_html.assert_called_once_with("2004-bmw-m3-coupe-232")
+    save_listing_html.assert_called_once_with(
+        "2004-bmw-m3-coupe-232",
+        "<html>raw</html>",
+    )
+    transform_listing_html.assert_called_once_with("2004-bmw-m3-coupe-232")
+    load_listing.assert_called_once_with({"listing_id": "2004-bmw-m3-coupe-232"})
+
+
+def test_main_requires_listing_id(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main([])
+
+    assert exc_info.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "the following arguments are required: listing_id" in stderr
+
+
+def test_main_help_exits_cleanly(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.main(["--help"])
+
+    assert exc_info.value.code == 0
+    stdout = capsys.readouterr().out
+    assert "Run the BAT ETL pipeline" in stdout


### PR DESCRIPTION
## What changed

- Added a minimal BAT CLI entrypoint runnable with `python -m app.cli <listing_id>`.
- Wired the CLI through the existing ingest -> transform -> load flow.
- Added focused CLI unit tests for parsing, help/error handling, and dispatch.
- Updated the README and marked the Phase 1 CLI item complete.

## Validation

- `.venv\Scripts\python.exe -m pytest -q` -> 74 passed
- `.venv\Scripts\python.exe -m pytest -q tests\unit` -> 69 passed
- `.venv\Scripts\python.exe -m pytest -q tests\unit\cli\test_main.py` -> 4 passed
- `python -m app.cli --help` printed usage successfully

## Notes

- A live CLI smoke run in the sandbox attempted to reach Bring a Trailer and failed because outbound network access is blocked here.
- `DATABASE_URL` is still required for the save, transform, and load steps.