### PR TITLE
[codex] Add minimal BAT CLI commands

### DIFF
--- a/app/sources/bat/cli.py
+++ b/app/sources/bat/cli.py
@@ -1,0 +1,53 @@
+import argparse
+
+from app.sources.bat.ingest import fetch_listing_html, save_listing_html
+from app.sources.bat.load import load_listing
+from app.sources.bat.transform import transform_listing_html
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description="Run Bring a Trailer ETL commands.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for command in ("ingest", "transform", "load", "run"):
+        subparser = subparsers.add_parser(command)
+        subparser.add_argument("--listing-id", required=True)
+
+    return parser
+
+
+def ingest_listing(listing_id):
+    html = fetch_listing_html(listing_id)
+    save_listing_html(listing_id, html)
+
+
+def transform_listing(listing_id):
+    return transform_listing_html(listing_id)
+
+
+def load_transformed_listing(listing_id):
+    transformed_listing = transform_listing_html(listing_id)
+    load_listing(transformed_listing)
+
+
+def run_listing(listing_id):
+    ingest_listing(listing_id)
+    transformed_listing = transform_listing(listing_id)
+    load_listing(transformed_listing)
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+
+    if args.command == "ingest":
+        ingest_listing(args.listing_id)
+    elif args.command == "transform":
+        transform_listing(args.listing_id)
+    elif args.command == "load":
+        load_transformed_listing(args.listing_id)
+    elif args.command == "run":
+        run_listing(args.listing_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/bat/test_cli.py
+++ b/tests/unit/bat/test_cli.py
@@ -1,0 +1,81 @@
+import pytest
+
+from app.sources.bat import cli
+
+
+def test_ingest_command_fetches_and_saves_listing_html(mocker):
+    fetch_listing_html = mocker.patch(
+        "app.sources.bat.cli.fetch_listing_html",
+        return_value="<html>Test</html>",
+    )
+    save_listing_html = mocker.patch("app.sources.bat.cli.save_listing_html")
+
+    cli.main(["ingest", "--listing-id", "test-id"])
+
+    fetch_listing_html.assert_called_once_with("test-id")
+    save_listing_html.assert_called_once_with("test-id", "<html>Test</html>")
+
+
+def test_transform_command_transforms_listing_html(mocker):
+    transform_listing_html = mocker.patch(
+        "app.sources.bat.cli.transform_listing_html",
+        return_value={"listing_id": "test-id"},
+    )
+
+    cli.main(["transform", "--listing-id", "test-id"])
+
+    transform_listing_html.assert_called_once_with("test-id")
+
+
+def test_load_command_transforms_and_loads_listing(mocker):
+    transformed_listing = {"listing_id": "test-id"}
+    transform_listing_html = mocker.patch(
+        "app.sources.bat.cli.transform_listing_html",
+        return_value=transformed_listing,
+    )
+    load_listing = mocker.patch("app.sources.bat.cli.load_listing")
+
+    cli.main(["load", "--listing-id", "test-id"])
+
+    transform_listing_html.assert_called_once_with("test-id")
+    load_listing.assert_called_once_with(transformed_listing)
+
+
+def test_run_command_executes_ingest_transform_load_in_order(mocker):
+    calls = []
+    transformed_listing = {"listing_id": "test-id"}
+
+    mocker.patch(
+        "app.sources.bat.cli.fetch_listing_html",
+        side_effect=lambda listing_id: calls.append(("fetch", listing_id)) or "<html>Test</html>",
+    )
+    mocker.patch(
+        "app.sources.bat.cli.save_listing_html",
+        side_effect=lambda listing_id, html: calls.append(("save", listing_id, html)),
+    )
+    mocker.patch(
+        "app.sources.bat.cli.transform_listing_html",
+        side_effect=lambda listing_id: calls.append(("transform", listing_id)) or transformed_listing,
+    )
+    mocker.patch(
+        "app.sources.bat.cli.load_listing",
+        side_effect=lambda listing: calls.append(("load", listing)),
+    )
+
+    cli.main(["run", "--listing-id", "test-id"])
+
+    assert calls == [
+        ("fetch", "test-id"),
+        ("save", "test-id", "<html>Test</html>"),
+        ("transform", "test-id"),
+        ("load", transformed_listing),
+    ]
+
+
+@pytest.mark.parametrize("command", ["ingest", "transform", "load", "run"])
+def test_commands_require_listing_id(command, capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main([command])
+
+    assert exc_info.value.code == 2
+    assert "--listing-id" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- Add a minimal BAT CLI entrypoint with `ingest`, `transform`, `load`, and `run` subcommands.
- Require `--listing-id` for every command.
- Reuse existing BAT ingest, transform, and load functions without adding dependencies or database configuration flags.
- Add unit coverage for command dispatch, missing `--listing-id`, and `run` execution order.

## Validation
- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_cli.py` passed with `8 passed`.
- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_ingest.py tests\unit\bat\test_transform.py tests\unit\bat\test_load.py tests\unit\bat\test_cli.py` passed with `69 passed`.
- `.venv\Scripts\python.exe -m app.sources.bat.cli --help` showed all four subcommands.
- `.venv\Scripts\python.exe -m app.sources.bat.cli ingest` failed as expected and reported missing `--listing-id`.

Closes #46