### PR TITLE
[codex] Fix BAT group-link taxonomy parsing

### DIFF
--- a/app/sources/bat/transform.py
+++ b/app/sources/bat/transform.py
@@ -127,16 +127,18 @@ def parse_make(soup):
     return extract_group_value(soup, "Make")
 
 def extract_group_value(soup: BeautifulSoup, label: str) -> str:
-    for button in soup.select("button.group-title"):
-        label_tag = button.select_one("strong.group-title-label")
-        if not label_tag:
-            continue
-
+    for label_tag in soup.select("strong.group-title-label"):
         if label_tag.get_text(strip=True) != label:
             continue
 
-        # Get the button text, then remove the label text from the front
-        full_text = button.get_text(" ", strip=True)
+        group_tag = (
+            label_tag.find_parent("button", class_="group-title")
+            or label_tag.find_parent("a", class_="group-link")
+        )
+        if not group_tag:
+            continue
+
+        full_text = group_tag.get_text(" ", strip=True)
         label_text = label_tag.get_text(" ", strip=True)
 
         value = full_text.removeprefix(label_text).strip()

--- a/tests/unit/bat/test_transform.py
+++ b/tests/unit/bat/test_transform.py
@@ -282,6 +282,21 @@ def test_parse_model_valid():
     model = transform.parse_model(soup)
     assert model == "Model Name"
 
+def test_parse_model_valid_group_link():
+    html_content = """
+    <html>
+        <body>
+            <a class="group-link" href="https://bringatrailer.com/porsche/911-carrera-3-2/">
+                <strong class="group-title-label">Model</strong>
+                Porsche 911 Carrera 3.2
+            </a>
+        </body>
+    </html>
+    """
+    soup = BeautifulSoup(html_content, "html.parser")
+    model = transform.parse_model(soup)
+    assert model == "Porsche 911 Carrera 3.2"
+
 def test_parse_model_not_found():
     html_content = """
     <html>
@@ -311,6 +326,21 @@ def test_parse_make_valid():
     soup = BeautifulSoup(html_content, "html.parser")
     make = transform.parse_make(soup)
     assert make == "Make Name"
+
+def test_parse_make_valid_group_link():
+    html_content = """
+    <html>
+        <body>
+            <a class="group-link" href="https://bringatrailer.com/porsche/">
+                <strong class="group-title-label">Make</strong>
+                Porsche
+            </a>
+        </body>
+    </html>
+    """
+    soup = BeautifulSoup(html_content, "html.parser")
+    make = transform.parse_make(soup)
+    assert make == "Porsche"
 
 def test_parse_make_not_found():
     html_content = """


### PR DESCRIPTION
## Summary
- Fix BAT Make/Model extraction when taxonomy metadata is rendered as `a.group-link` instead of `button.group-title`.
- Keep support for the existing button-based markup.
- Add unit coverage for group-link Make and Model parsing.

## Root Cause
BAT listing HTML for `1987-porsche-911-carrera-coupe-114` contains valid `strong.group-title-label` elements, but their parent container is now `a.group-link`. The parser only iterated `button.group-title`, so it raised `ValueError: Could not find 'Make' group` before reaching the rest of the transform.

## Validation
- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_transform.py` -> 53 passed
- `.venv\Scripts\python.exe -m app.sources.bat.cli transform --listing-id 1987-porsche-911-carrera-coupe-114` -> exited successfully against local stored raw HTML

Closes #48