### PR TITLE
[codex] Add BAT ETL logging

### DIFF
--- a/app/sources/bat/cli.py
+++ b/app/sources/bat/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 
 from dotenv import load_dotenv
 
@@ -7,6 +8,8 @@ from app.sources.bat.load import load_listing
 from app.sources.bat.transform import transform_listing_html
 
 load_dotenv()
+
+logger = logging.getLogger(__name__)
 
 
 def build_parser():
@@ -18,6 +21,13 @@ def build_parser():
         subparser.add_argument("--listing-id", required=True)
 
     return parser
+
+
+def configure_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s %(name)s %(message)s",
+    )
 
 
 def ingest_listing(listing_id):
@@ -41,16 +51,23 @@ def run_listing(listing_id):
 
 
 def main(argv=None):
+    configure_logging()
     args = build_parser().parse_args(argv)
 
-    if args.command == "ingest":
-        ingest_listing(args.listing_id)
-    elif args.command == "transform":
-        transform_listing(args.listing_id)
-    elif args.command == "load":
-        load_transformed_listing(args.listing_id)
-    elif args.command == "run":
-        run_listing(args.listing_id)
+    logger.info("BAT %s command started for listing_id=%s", args.command, args.listing_id)
+    try:
+        if args.command == "ingest":
+            ingest_listing(args.listing_id)
+        elif args.command == "transform":
+            transform_listing(args.listing_id)
+        elif args.command == "load":
+            load_transformed_listing(args.listing_id)
+        elif args.command == "run":
+            run_listing(args.listing_id)
+    except Exception:
+        logger.exception("BAT %s command failed for listing_id=%s", args.command, args.listing_id)
+        raise
+    logger.info("BAT %s command completed for listing_id=%s", args.command, args.listing_id)
 
 
 if __name__ == "__main__":

--- a/app/sources/bat/ingest.py
+++ b/app/sources/bat/ingest.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import psycopg
@@ -5,6 +6,7 @@ import requests
 
 
 SOURCE_SITE = "bringatrailer"
+logger = logging.getLogger(__name__)
 
 UPSERT_RAW_LISTING_HTML_SQL = """
 INSERT INTO raw_listing_html (
@@ -29,8 +31,10 @@ ON CONFLICT (source_site, source_listing_id) DO UPDATE SET
 
 def fetch_listing_html(id):
     url = f"https://bringatrailer.com/listing/{id}"
+    logger.info("Fetching BAT listing HTML for listing_id=%s", id)
     response = requests.get(url, timeout=10)
     response.raise_for_status()
+    logger.info("Fetched BAT listing HTML for listing_id=%s", id)
     return response.text
 
 
@@ -44,6 +48,7 @@ def save_listing_html(listing_id, html, url=None):
     with psycopg.connect(database_url) as conn:
         with conn.cursor() as cur:
             cur.execute(UPSERT_RAW_LISTING_HTML_SQL, params)
+            logger.info("Saved BAT raw listing HTML for listing_id=%s", listing_id)
 
 
 def build_raw_listing_html_params(listing_id, html, url=None):

--- a/app/sources/bat/load.py
+++ b/app/sources/bat/load.py
@@ -1,7 +1,10 @@
+import logging
 import os
 
 import psycopg
 from psycopg.types.json import Jsonb
+
+logger = logging.getLogger(__name__)
 
 
 INSERT_LISTING_SQL = """
@@ -66,7 +69,9 @@ def load_listing(transformed_listing):
     with psycopg.connect(database_url) as conn:
         with conn.cursor() as cur:
             cur.execute(INSERT_LISTING_SQL, params)
+            logger.info("Upserted BAT listing for listing_id=%s", params["source_listing_id"])
             cur.execute(MARK_RAW_LISTING_PROCESSED_SQL, params)
+            logger.info("Marked BAT raw listing processed for listing_id=%s", params["source_listing_id"])
 
 
 def build_listing_params(transformed_listing):

--- a/app/sources/bat/transform.py
+++ b/app/sources/bat/transform.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import re
 from datetime import datetime
@@ -7,6 +8,7 @@ import psycopg
 
 
 SOURCE_SITE = "bringatrailer"
+logger = logging.getLogger(__name__)
 
 SELECT_RAW_LISTING_HTML_SQL = """
 SELECT raw_html
@@ -42,6 +44,7 @@ def build_raw_listing_lookup_params(listing_id):
 
 
 def transform_listing_html(listing_id):
+    logger.info("Transforming BAT listing HTML for listing_id=%s", listing_id)
     html = load_listing_html(listing_id)
     soup = BeautifulSoup(html, "html.parser")
     product_data = get_product_json_ld(soup)
@@ -75,6 +78,7 @@ def transform_listing_html(listing_id):
         "transmission": transmission,
         "listing_details_raw": listing_details,
     }
+    logger.info("Transformed BAT listing HTML for listing_id=%s", listing_id)
     return transformed_data
 
 def get_product_json_ld(soup):

--- a/tests/unit/bat/test_cli.py
+++ b/tests/unit/bat/test_cli.py
@@ -1,19 +1,25 @@
+import logging
+
 import pytest
 
 from app.sources.bat import cli
 
 
-def test_ingest_command_fetches_and_saves_listing_html(mocker):
+def test_ingest_command_fetches_and_saves_listing_html(mocker, caplog):
     fetch_listing_html = mocker.patch(
         "app.sources.bat.cli.fetch_listing_html",
         return_value="<html>Test</html>",
     )
     save_listing_html = mocker.patch("app.sources.bat.cli.save_listing_html")
 
+    caplog.set_level(logging.INFO)
     cli.main(["ingest", "--listing-id", "test-id"])
 
     fetch_listing_html.assert_called_once_with("test-id")
     save_listing_html.assert_called_once_with("test-id", "<html>Test</html>")
+    assert "BAT ingest command started for listing_id=test-id" in caplog.text
+    assert "BAT ingest command completed for listing_id=test-id" in caplog.text
+    assert "<html>Test</html>" not in caplog.text
 
 
 def test_transform_command_transforms_listing_html(mocker):
@@ -25,6 +31,22 @@ def test_transform_command_transforms_listing_html(mocker):
     cli.main(["transform", "--listing-id", "test-id"])
 
     transform_listing_html.assert_called_once_with("test-id")
+
+
+def test_transform_command_logs_failure_and_reraises_original_exception(mocker, caplog):
+    error = RuntimeError("transform failed")
+    mocker.patch(
+        "app.sources.bat.cli.transform_listing_html",
+        side_effect=error,
+    )
+
+    caplog.set_level(logging.INFO)
+    with pytest.raises(RuntimeError) as exc_info:
+        cli.main(["transform", "--listing-id", "test-id"])
+
+    assert exc_info.value is error
+    assert "BAT transform command started for listing_id=test-id" in caplog.text
+    assert "BAT transform command failed for listing_id=test-id" in caplog.text
 
 
 def test_load_command_transforms_and_loads_listing(mocker):

--- a/tests/unit/bat/test_ingest.py
+++ b/tests/unit/bat/test_ingest.py
@@ -1,10 +1,12 @@
+import logging
+
 import pytest
 import requests
 from app.sources.bat import ingest
 from app.sources.bat.ingest import fetch_listing_html, save_listing_html
 
 # test that the function returns the correct HTML and that the request is made with the correct URL
-def test_fetch_listing_html(mocker):
+def test_fetch_listing_html(mocker, caplog):
     # create mock request
     mock_get = mocker.patch('app.sources.bat.ingest.requests.get')
     # set return value for mock request
@@ -12,11 +14,15 @@ def test_fetch_listing_html(mocker):
     mock_get.return_value.raise_for_status.return_value = None
 
     # call the function being tested
+    caplog.set_level(logging.INFO)
     response = fetch_listing_html("test-id")
 
     # assert that the response is correct and that the mock request was called with the correct URL
     assert response == "<html>Test</html>"
     mock_get.assert_called_once_with("https://bringatrailer.com/listing/test-id", timeout=10)
+    assert "Fetching BAT listing HTML for listing_id=test-id" in caplog.text
+    assert "Fetched BAT listing HTML for listing_id=test-id" in caplog.text
+    assert "<html>Test</html>" not in caplog.text
 
 # test that an HTTP error is raised when the request fails
 def test_fetch_listing_html_bad_response(mocker):
@@ -62,7 +68,7 @@ def test_build_raw_listing_html_params_defaults_bat_url():
     assert params["url"] == "https://bringatrailer.com/listing/test-id/"
 
 
-def test_save_listing_html_executes_upsert_with_expected_conflict_target(mocker):
+def test_save_listing_html_executes_upsert_with_expected_conflict_target(mocker, caplog):
     calls = {}
 
     class FakeCursor:
@@ -96,6 +102,7 @@ def test_save_listing_html_executes_upsert_with_expected_conflict_target(mocker)
     )
     mocker.patch.object(ingest.psycopg, "connect", side_effect=fake_connect)
 
+    caplog.set_level(logging.INFO)
     save_listing_html(
         "test-id",
         "<html>Test</html>",
@@ -111,6 +118,9 @@ def test_save_listing_html_executes_upsert_with_expected_conflict_target(mocker)
         "url": "https://example.test/listing/test-id",
         "raw_html": "<html>Test</html>",
     }
+    assert "Saved BAT raw listing HTML for listing_id=test-id" in caplog.text
+    assert "<html>Test</html>" not in caplog.text
+    assert "postgresql://user:pass@localhost/db" not in caplog.text
 
 
 def test_save_listing_html_requires_database_url(mocker):

--- a/tests/unit/bat/test_load.py
+++ b/tests/unit/bat/test_load.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from app.sources.bat import load
@@ -25,7 +27,7 @@ def test_build_listing_params_maps_transformed_listing_to_schema_columns():
     ]
 
 
-def test_load_listing_executes_upsert_with_expected_conflict_target(mocker):
+def test_load_listing_executes_upsert_with_expected_conflict_target(mocker, caplog):
     calls = {"executions": []}
 
     class FakeCursor:
@@ -58,6 +60,7 @@ def test_load_listing_executes_upsert_with_expected_conflict_target(mocker):
     )
     mocker.patch.object(load.psycopg, "connect", side_effect=fake_connect)
 
+    caplog.set_level(logging.INFO)
     load.load_listing(_transformed_listing())
 
     listing_sql, listing_params = calls["executions"][0]
@@ -77,6 +80,9 @@ def test_load_listing_executes_upsert_with_expected_conflict_target(mocker):
     assert "source_site = %(source_site)s" in processed_sql
     assert "source_listing_id = %(source_listing_id)s" in processed_sql
     assert processed_params is listing_params
+    assert "Upserted BAT listing for listing_id=test-listing" in caplog.text
+    assert "Marked BAT raw listing processed for listing_id=test-listing" in caplog.text
+    assert "postgresql://user:pass@localhost/db" not in caplog.text
 
 
 def test_load_listing_requires_database_url(mocker):

--- a/tests/unit/bat/test_transform.py
+++ b/tests/unit/bat/test_transform.py
@@ -1,3 +1,5 @@
+import logging
+
 from bs4 import BeautifulSoup
 import pytest
 
@@ -101,6 +103,31 @@ def test_load_listing_html_requires_database_url(mocker):
 
     with pytest.raises(RuntimeError, match="DATABASE_URL must be set"):
         transform.load_listing_html("test-id")
+
+
+def test_transform_listing_html_logs_success_without_raw_html(mocker, caplog):
+    mocker.patch.object(transform, "load_listing_html", return_value="<html>SENSITIVE_RAW_HTML</html>")
+    mocker.patch.object(transform, "get_product_json_ld", return_value={"name": "One Owner 2004 BMW M3"})
+    mocker.patch.object(transform, "extract_listing_title", return_value="2004 BMW M3")
+    mocker.patch.object(transform, "get_listing_details", return_value=["Chassis: WBSBL93414PN57203"])
+    mocker.patch.object(transform, "parse_year", return_value=2004)
+    mocker.patch.object(transform, "parse_make", return_value="BMW")
+    mocker.patch.object(transform, "parse_model", return_value="M3")
+    mocker.patch.object(transform, "find_detail_value", side_effect=["50,250 Miles", "Chassis: WBSBL93414PN57203", "6-Speed Manual Transmission"])
+    mocker.patch.object(transform, "parse_mileage", return_value=50250)
+    mocker.patch.object(transform, "extract_vin", return_value="WBSBL93414PN57203")
+    mocker.patch.object(transform, "extract_sale_price", return_value=19750)
+    mocker.patch.object(transform, "extract_sold_status", return_value=True)
+    mocker.patch.object(transform, "extract_auction_end_date", return_value="2026-03-30")
+    mocker.patch.object(transform, "normalize_transmission", return_value="manual")
+
+    caplog.set_level(logging.INFO)
+    transformed = transform.transform_listing_html("test-id")
+
+    assert transformed["listing_id"] == "test-id"
+    assert "Transforming BAT listing HTML for listing_id=test-id" in caplog.text
+    assert "Transformed BAT listing HTML for listing_id=test-id" in caplog.text
+    assert "SENSITIVE_RAW_HTML" not in caplog.text
 
 def test_get_product_json_ld_returns_product_data(tmp_path):
     # create a test HTML file with a valid JSON-LD script tag


### PR DESCRIPTION
## Summary

- Add standard-library logging to the Bring a Trailer single-listing ETL CLI and pipeline modules.
- Log CLI command start, completion, and failure while preserving original exception propagation.
- Log listing-scoped ingest, transform, and load milestones without logging raw HTML, database URLs, credentials, or other sensitive values.
- Add focused unit tests for lifecycle logs, failure logging, listing IDs in logs, and representative sensitive-value exclusions.

## Validation

```powershell
.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_cli.py tests\unit\bat\test_ingest.py tests\unit\bat\test_transform.py tests\unit\bat\test_load.py
```

Result: 73 passed in 0.51s.

## QA

- QA review passed with no confirmed bugs, regressions, missing required tests, or scope drift.
- No integration or manual CLI/container run was performed because the approved plan scoped verification to focused unit tests.

Closes #51