### PR TITLE
[codex] Avoid duplicate BAT CLI traceback logging

### DIFF
--- a/app/sources/bat/cli.py
+++ b/app/sources/bat/cli.py
@@ -65,7 +65,7 @@ def main(argv=None):
         elif args.command == "run":
             run_listing(args.listing_id)
     except Exception:
-        logger.exception("BAT %s command failed for listing_id=%s", args.command, args.listing_id)
+        logger.error("BAT %s command failed for listing_id=%s", args.command, args.listing_id)
         raise
     logger.info("BAT %s command completed for listing_id=%s", args.command, args.listing_id)
 

--- a/tests/unit/bat/test_cli.py
+++ b/tests/unit/bat/test_cli.py
@@ -33,7 +33,7 @@ def test_transform_command_transforms_listing_html(mocker):
     transform_listing_html.assert_called_once_with("test-id")
 
 
-def test_transform_command_logs_failure_and_reraises_original_exception(mocker, caplog):
+def test_transform_command_logs_failure_context_without_traceback_and_reraises(mocker, caplog):
     error = RuntimeError("transform failed")
     mocker.patch(
         "app.sources.bat.cli.transform_listing_html",
@@ -47,6 +47,8 @@ def test_transform_command_logs_failure_and_reraises_original_exception(mocker, 
     assert exc_info.value is error
     assert "BAT transform command started for listing_id=test-id" in caplog.text
     assert "BAT transform command failed for listing_id=test-id" in caplog.text
+    assert "Traceback" not in caplog.text
+    assert "RuntimeError: transform failed" not in caplog.text
 
 
 def test_load_command_transforms_and_loads_listing(mocker):


### PR DESCRIPTION
## Summary

- Replace BAT CLI failure logging with a non-traceback error log before re-raising.
- Keep command/listing failure context and preserve nonzero CLI failure behavior.
- Update CLI unit coverage to assert failure logs do not include duplicate traceback text.

## Validation

- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_cli.py`
- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat`

Closes #53