### PR TITLE
[codex] Strengthen BAT transmission parsing

### DIFF
--- a/app/sources/bat/transform.py
+++ b/app/sources/bat/transform.py
@@ -17,6 +17,12 @@ WHERE source_site = %(source_site)s
   AND source_listing_id = %(source_listing_id)s
 """
 
+TRANSMISSION_DETAIL_PATTERN = (
+    r"\b(?:Transmission|Transaxle|Gearbox)\b"
+    r"|"
+    r"\b(?:column|floor|console|dash)-?shift(?:ed)?\b.*\b(?:\w+-)?speed\b.*\b(?:manual|automatic)\b"
+)
+
 
 def load_listing_html(listing_id):
     database_url = os.environ.get("DATABASE_URL")
@@ -60,7 +66,7 @@ def transform_listing_html(listing_id):
     sale_price = extract_sale_price(soup, product_data)
     sold = extract_sold_status(soup)
     auction_end_date = extract_auction_end_date(soup)
-    transmission = normalize_transmission(find_detail_value(listing_details, r"\b(?:Transmission|Transaxle|Gearbox)\b", "Transmission"))
+    transmission = normalize_transmission(find_detail_value(listing_details, TRANSMISSION_DETAIL_PATTERN, "Transmission"))
 
     # transaformed data object
     transformed_data = {

--- a/tests/unit/bat/test_transform.py
+++ b/tests/unit/bat/test_transform.py
@@ -502,7 +502,7 @@ def test_find_detail_value_valid_transmission():
         "Four speed manual transmission",
         "3.2-Liter S54 Inline-Six",
     ]
-    assert transform.find_detail_value(values, r"\b(?:Transmission|Transaxle|Gearbox)\b", "Transmission") == "Four speed manual transmission"
+    assert transform.find_detail_value(values, transform.TRANSMISSION_DETAIL_PATTERN, "Transmission") == "Four speed manual transmission"
 
 def test_find_detail_value_valid_tranaxle():
     values = [
@@ -510,7 +510,7 @@ def test_find_detail_value_valid_tranaxle():
         "6-Speed manual transaxle",
         "3.2-Liter S54 Inline-Six",
     ]
-    assert transform.find_detail_value(values, r"\b(?:Transmission|Transaxle|Gearbox)\b", "Transmission") == "6-Speed manual transaxle"
+    assert transform.find_detail_value(values, transform.TRANSMISSION_DETAIL_PATTERN, "Transmission") == "6-Speed manual transaxle"
 
 def test_find_detail_value_valid_gearbox():
     values = [
@@ -518,7 +518,23 @@ def test_find_detail_value_valid_gearbox():
         "Automatic gearbox",
         "3.2-Liter S54 Inline-Six",
     ]
-    assert transform.find_detail_value(values, r"\b(?:Transmission|Transaxle|Gearbox)\b", "Transmission") == "Automatic gearbox"
+    assert transform.find_detail_value(values, transform.TRANSMISSION_DETAIL_PATTERN, "Transmission") == "Automatic gearbox"
+
+def test_find_detail_value_valid_column_shifted_manual_without_transmission_keyword():
+    values = [
+        "Chassis: CE145Z164835",
+        "Column-Shifted Three-Speed Manual",
+        "235ci Inline-Six",
+    ]
+    assert transform.find_detail_value(values, transform.TRANSMISSION_DETAIL_PATTERN, "Transmission") == "Column-Shifted Three-Speed Manual"
+
+def test_find_detail_value_valid_floor_shift_manual_without_transmission_keyword():
+    values = [
+        "Chassis: WBSBL93414PN57203",
+        "Floor-Shift Four-Speed Manual",
+        "3.2-Liter S54 Inline-Six",
+    ]
+    assert transform.find_detail_value(values, transform.TRANSMISSION_DETAIL_PATTERN, "Transmission") == "Floor-Shift Four-Speed Manual"
 
 def test_find_detail_value_transmission_not_found():
     values = [
@@ -526,7 +542,17 @@ def test_find_detail_value_transmission_not_found():
         "3.2-Liter S54 Inline-Six",
     ]
     with pytest.raises(ValueError, match="Could not parse Transmission"):
-        transform.find_detail_value(values, r"\b(?:Transmission|Transaxle|Gearbox)\b", "Transmission")
+        transform.find_detail_value(values, transform.TRANSMISSION_DETAIL_PATTERN, "Transmission")
+
+def test_find_detail_value_transmission_ignores_unrelated_manual_details():
+    values = [
+        "Chassis: CE145Z164835",
+        "Manual Steering",
+        "Manual Brakes",
+        "235ci Inline-Six",
+    ]
+    with pytest.raises(ValueError, match="Could not parse Transmission"):
+        transform.find_detail_value(values, transform.TRANSMISSION_DETAIL_PATTERN, "Transmission")
 
 def test_extract_vin_valid():
     raw_vin = "Chassis: WBSBL93414PN57203"


### PR DESCRIPTION
## Summary

- Add a named BAT transmission detail selector that preserves `Transmission`, `Transaxle`, and `Gearbox` matches.
- Recognize narrow shift-pattern and gear-count phrases such as `Column-Shifted Three-Speed Manual`.
- Add focused unit coverage for the observed phrase, a nearby valid variant, and unrelated manual details that should not match.

## Root Cause

BAT listing details can describe the transmission with shift-pattern phrasing and gear count without using `Transmission`, `Transaxle`, or `Gearbox`, so the previous selector missed valid transmission rows before normalization.

## Validation

- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_transform.py` -> `57 passed`
- `.venv\Scripts\python.exe -m pytest -q` -> `81 passed`
- `transform_listing_html("1965-chevrolet-c10-pickup-134")` from stored raw HTML -> `transmission: manual`

Closes #54