### PR TITLE
[codex] Discover and ingest recent BAT listings

### DIFF
--- a/app/db/schema.sql
+++ b/app/db/schema.sql
@@ -32,3 +32,15 @@ CREATE TABLE IF NOT EXISTS raw_listing_html (
     processed BOOLEAN NOT NULL DEFAULT FALSE,
     UNIQUE (source_site, source_listing_id)
 );
+
+CREATE TABLE IF NOT EXISTS discovered_listings (
+    id BIGSERIAL PRIMARY KEY,
+    source_site TEXT NOT NULL,
+    source_listing_id TEXT NOT NULL,
+    url TEXT NOT NULL,
+    eligible BOOLEAN NOT NULL DEFAULT TRUE,
+    skip_reason TEXT,
+    ingested_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (source_site, source_listing_id)
+);

--- a/app/sources/bat/cli.py
+++ b/app/sources/bat/cli.py
@@ -3,6 +3,7 @@ import logging
 
 from dotenv import load_dotenv
 
+from app.sources.bat.discover import run_daily_discovery
 from app.sources.bat.ingest import fetch_listing_html, save_listing_html
 from app.sources.bat.load import load_listing
 from app.sources.bat.transform import transform_listing_html
@@ -19,6 +20,9 @@ def build_parser():
     for command in ("ingest", "transform", "load", "run"):
         subparser = subparsers.add_parser(command)
         subparser.add_argument("--listing-id", required=True)
+
+    discover_parser = subparsers.add_parser("discover")
+    discover_parser.add_argument("--max-pages", type=int, default=5)
 
     return parser
 
@@ -50,11 +54,16 @@ def run_listing(listing_id):
     load_listing(transformed_listing)
 
 
+def discover_and_ingest(max_pages):
+    return run_daily_discovery(max_pages=max_pages)
+
+
 def main(argv=None):
     configure_logging()
     args = build_parser().parse_args(argv)
 
-    logger.info("BAT %s command started for listing_id=%s", args.command, args.listing_id)
+    listing_id = getattr(args, "listing_id", None)
+    logger.info("BAT %s command started for listing_id=%s", args.command, listing_id)
     try:
         if args.command == "ingest":
             ingest_listing(args.listing_id)
@@ -64,10 +73,12 @@ def main(argv=None):
             load_transformed_listing(args.listing_id)
         elif args.command == "run":
             run_listing(args.listing_id)
+        elif args.command == "discover":
+            discover_and_ingest(args.max_pages)
     except Exception:
-        logger.error("BAT %s command failed for listing_id=%s", args.command, args.listing_id)
+        logger.error("BAT %s command failed for listing_id=%s", args.command, listing_id)
         raise
-    logger.info("BAT %s command completed for listing_id=%s", args.command, args.listing_id)
+    logger.info("BAT %s command completed for listing_id=%s", args.command, listing_id)
 
 
 if __name__ == "__main__":

--- a/app/sources/bat/discover.py
+++ b/app/sources/bat/discover.py
@@ -1,0 +1,342 @@
+import logging
+import os
+import re
+from dataclasses import dataclass
+from urllib.parse import urljoin, urlparse
+
+import psycopg
+import requests
+from bs4 import BeautifulSoup
+
+from app.sources.bat.ingest import SOURCE_SITE, fetch_listing_html, save_listing_html
+from app.sources.bat.load import load_listing
+from app.sources.bat.transform import transform_listing_html
+
+
+RESULTS_URL = "https://bringatrailer.com/auctions/results/"
+UNSUPPORTED_SKIP_REASON = "unsupported_listing_type"
+AMBIGUOUS_SKIP_REASON = "ambiguous_listing_type"
+
+UNSUPPORTED_TERMS = (
+    "automobilia",
+    "boat",
+    "boats",
+    "book",
+    "brochure",
+    "collectible",
+    "collectibles",
+    "engine",
+    "memorabilia",
+    "motorcycle",
+    "motorcycles",
+    "parts",
+    "sign",
+    "signage",
+    "trailer",
+    "trailers",
+    "watch",
+    "wheels",
+)
+
+UPSERT_DISCOVERED_LISTING_SQL = """
+INSERT INTO discovered_listings (
+    source_site,
+    source_listing_id,
+    url,
+    eligible,
+    skip_reason
+) VALUES (
+    %(source_site)s,
+    %(source_listing_id)s,
+    %(url)s,
+    %(eligible)s,
+    %(skip_reason)s
+)
+ON CONFLICT (source_site, source_listing_id) DO UPDATE SET
+    url = EXCLUDED.url,
+    eligible = EXCLUDED.eligible,
+    skip_reason = EXCLUDED.skip_reason
+"""
+
+SELECT_EXISTING_DISCOVERED_IDS_SQL = """
+SELECT source_listing_id
+FROM discovered_listings
+WHERE source_site = %(source_site)s
+  AND source_listing_id = ANY(%(source_listing_ids)s)
+"""
+
+SELECT_PENDING_ELIGIBLE_DISCOVERED_SQL = """
+SELECT source_listing_id, url
+FROM discovered_listings
+WHERE source_site = %(source_site)s
+  AND eligible = TRUE
+  AND ingested_at IS NULL
+ORDER BY created_at ASC, id ASC
+"""
+
+MARK_DISCOVERED_LISTING_INGESTED_SQL = """
+UPDATE discovered_listings
+SET ingested_at = NOW()
+WHERE source_site = %(source_site)s
+  AND source_listing_id = %(source_listing_id)s
+"""
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DiscoveredListing:
+    source_listing_id: str
+    url: str
+    eligible: bool
+    skip_reason: str | None = None
+
+
+def build_results_page_url(page_number):
+    if page_number < 1:
+        raise ValueError("page_number must be >= 1")
+    if page_number == 1:
+        return RESULTS_URL
+    return f"{RESULTS_URL}?page={page_number}"
+
+
+def fetch_results_page(url):
+    logger.info("Fetching BAT discovery results page url=%s", url)
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    logger.info("Fetched BAT discovery results page url=%s", url)
+    return response.text
+
+
+def parse_results_page(html, base_url=RESULTS_URL):
+    soup = BeautifulSoup(html, "html.parser")
+    listings = []
+    seen_listing_ids = set()
+
+    for link in soup.find_all("a", href=True):
+        try:
+            listing_id, url = normalize_listing_url(link["href"], base_url)
+        except ValueError:
+            continue
+
+        if listing_id in seen_listing_ids:
+            continue
+
+        seen_listing_ids.add(listing_id)
+        eligible, skip_reason = classify_listing(_candidate_text(link))
+        listings.append(
+            DiscoveredListing(
+                source_listing_id=listing_id,
+                url=url,
+                eligible=eligible,
+                skip_reason=skip_reason,
+            )
+        )
+
+    return listings
+
+
+def normalize_listing_url(href, base_url=RESULTS_URL):
+    absolute_url = urljoin(base_url, href)
+    parsed = urlparse(absolute_url)
+    if parsed.netloc.lower() != "bringatrailer.com":
+        raise ValueError("Listing URL must be on bringatrailer.com")
+
+    match = re.match(r"^/listing/([^/?#]+)/?$", parsed.path)
+    if not match:
+        raise ValueError("URL is not a BAT listing URL")
+
+    listing_id = match.group(1).strip().lower()
+    if not listing_id:
+        raise ValueError("Listing URL missing listing ID")
+
+    return listing_id, f"https://bringatrailer.com/listing/{listing_id}/"
+
+
+def classify_listing(text):
+    normalized_text = re.sub(r"\s+", " ", text or "").strip().lower()
+    if not normalized_text:
+        return False, AMBIGUOUS_SKIP_REASON
+
+    if any(re.search(rf"\b{re.escape(term)}\b", normalized_text) for term in UNSUPPORTED_TERMS):
+        return False, UNSUPPORTED_SKIP_REASON
+
+    if not re.search(r"\b(?:18|19|20)\d{2}\b", normalized_text):
+        return False, AMBIGUOUS_SKIP_REASON
+
+    return True, None
+
+
+def build_discovered_listing_params(listing):
+    return {
+        "source_site": SOURCE_SITE,
+        "source_listing_id": listing.source_listing_id,
+        "url": listing.url,
+        "eligible": listing.eligible,
+        "skip_reason": listing.skip_reason,
+    }
+
+
+def save_discovered_listings(listings):
+    if not listings:
+        return []
+
+    database_url = _database_url()
+    listing_ids = [listing.source_listing_id for listing in listings]
+
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            existing_ids = select_existing_discovered_ids(cur, listing_ids)
+            for listing in listings:
+                cur.execute(UPSERT_DISCOVERED_LISTING_SQL, build_discovered_listing_params(listing))
+
+    return [listing_id for listing_id in listing_ids if listing_id not in existing_ids]
+
+
+def select_existing_discovered_ids(cur, listing_ids):
+    cur.execute(
+        SELECT_EXISTING_DISCOVERED_IDS_SQL,
+        {
+            "source_site": SOURCE_SITE,
+            "source_listing_ids": listing_ids,
+        },
+    )
+    return {row[0] for row in cur.fetchall()}
+
+
+def load_pending_eligible_discovered_listings():
+    database_url = _database_url()
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(SELECT_PENDING_ELIGIBLE_DISCOVERED_SQL, {"source_site": SOURCE_SITE})
+            return [
+                DiscoveredListing(
+                    source_listing_id=row[0],
+                    url=row[1],
+                    eligible=True,
+                    skip_reason=None,
+                )
+                for row in cur.fetchall()
+            ]
+
+
+def mark_discovered_listing_ingested(listing_id):
+    database_url = _database_url()
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                MARK_DISCOVERED_LISTING_INGESTED_SQL,
+                {
+                    "source_site": SOURCE_SITE,
+                    "source_listing_id": listing_id,
+                },
+            )
+
+
+def discover_recent_listings(max_pages, fetch_page=fetch_results_page, save_listings=save_discovered_listings):
+    if max_pages < 1:
+        raise ValueError("max_pages must be >= 1")
+
+    discovered_count = 0
+    new_listing_ids = []
+
+    for page_number in range(1, max_pages + 1):
+        page_url = build_results_page_url(page_number)
+        listings = parse_results_page(fetch_page(page_url), page_url)
+        page_new_listing_ids = save_listings(listings)
+        discovered_count += len(listings)
+        new_listing_ids.extend(page_new_listing_ids)
+
+        logger.info(
+            "Processed BAT discovery page page_number=%s discovered=%s new=%s",
+            page_number,
+            len(listings),
+            len(page_new_listing_ids),
+        )
+        if not page_new_listing_ids:
+            break
+
+    return {
+        "discovered_count": discovered_count,
+        "new_listing_ids": new_listing_ids,
+    }
+
+
+def ingest_pending_discovered_listings(load_pending=load_pending_eligible_discovered_listings):
+    ingested_listing_ids = []
+
+    for listing in load_pending():
+        html = fetch_listing_html(listing.source_listing_id)
+        save_listing_html(listing.source_listing_id, html, listing.url)
+        mark_discovered_listing_ingested(listing.source_listing_id)
+        transformed_listing = transform_listing_html(listing.source_listing_id)
+        load_listing(transformed_listing)
+        ingested_listing_ids.append(listing.source_listing_id)
+
+    return ingested_listing_ids
+
+
+def run_daily_discovery(max_pages):
+    discovery_result = discover_recent_listings(max_pages)
+    ingested_listing_ids = ingest_pending_discovered_listings()
+    return {
+        **discovery_result,
+        "ingested_listing_ids": ingested_listing_ids,
+    }
+
+
+def _candidate_text(link):
+    direct_text = _link_title_text(link)
+    if direct_text:
+        return direct_text
+
+    for parent in link.parents:
+        if parent.name in ("article", "li"):
+            return _card_title_text(parent) or parent.get_text(" ", strip=True)
+        if parent.name == "div" and _looks_like_listing_card(parent):
+            return _card_title_text(parent) or parent.get_text(" ", strip=True)
+    return link.get_text(" ", strip=True)
+
+
+def _looks_like_listing_card(tag):
+    class_text = " ".join(tag.get("class", [])).lower()
+    return any(token in class_text for token in ("auction", "listing", "result", "post"))
+
+
+def _link_title_text(link):
+    text = link.get_text(" ", strip=True)
+    if text:
+        return text
+
+    title = link.get("title")
+    if title:
+        return title.strip()
+
+    image = link.find("img")
+    if image and image.get("alt"):
+        return image["alt"].strip()
+
+    return ""
+
+
+def _card_title_text(card):
+    title_link = card.select_one("h1 a, h2 a, h3 a, h4 a")
+    if title_link:
+        return _link_title_text(title_link)
+
+    title = card.select_one("h1, h2, h3, h4")
+    if title:
+        return title.get_text(" ", strip=True)
+
+    image = card.find("img", alt=True)
+    if image:
+        return image["alt"].strip()
+
+    return ""
+
+
+def _database_url():
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set")
+    return database_url

--- a/tests/integration/test_postgres_schema.py
+++ b/tests/integration/test_postgres_schema.py
@@ -135,6 +135,74 @@ def test_schema_sql_applies_in_isolated_postgres_container():
             """,
         )
         assert raw_defaults == ["false|t"]
+
+        discovered_column_rows = _psql(
+            container_name,
+            """
+            SELECT column_name || ':' || data_type || ':' || is_nullable
+            FROM information_schema.columns
+            WHERE table_name = 'discovered_listings'
+              AND column_name IN (
+                  'id',
+                  'source_site',
+                  'source_listing_id',
+                  'url',
+                  'eligible',
+                  'skip_reason',
+                  'ingested_at',
+                  'created_at'
+              )
+            ORDER BY column_name;
+            """,
+        )
+        assert discovered_column_rows == [
+            "created_at:timestamp with time zone:NO",
+            "eligible:boolean:NO",
+            "id:bigint:NO",
+            "ingested_at:timestamp with time zone:YES",
+            "skip_reason:text:YES",
+            "source_listing_id:text:NO",
+            "source_site:text:NO",
+            "url:text:NO",
+        ]
+
+        discovered_unique_columns = _psql(
+            container_name,
+            """
+            SELECT string_agg(a.attname, ',' ORDER BY array_position(c.conkey, a.attnum))
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(c.conkey)
+            WHERE t.relname = 'discovered_listings'
+              AND c.contype = 'u'
+            GROUP BY c.oid;
+            """,
+        )
+        assert "source_site,source_listing_id" in discovered_unique_columns
+
+        discovered_defaults = _psql(
+            container_name,
+            """
+            WITH inserted AS (
+                INSERT INTO discovered_listings (
+                    source_site,
+                    source_listing_id,
+                    url
+                ) VALUES (
+                    'bringatrailer',
+                    'schema-discovery-test',
+                    'https://bringatrailer.com/listing/schema-discovery-test/'
+                )
+                RETURNING eligible, skip_reason, ingested_at, created_at
+            )
+            SELECT eligible::text,
+                   skip_reason IS NULL,
+                   ingested_at IS NULL,
+                   created_at IS NOT NULL
+            FROM inserted;
+            """,
+        )
+        assert discovered_defaults == ["true|t|t|t"]
     finally:
         subprocess.run(["docker", "rm", "-f", container_name], capture_output=True, text=True)
 

--- a/tests/unit/bat/test_cli.py
+++ b/tests/unit/bat/test_cli.py
@@ -96,6 +96,14 @@ def test_run_command_executes_ingest_transform_load_in_order(mocker):
     ]
 
 
+def test_discover_command_runs_daily_discovery_with_max_pages(mocker):
+    run_daily_discovery = mocker.patch("app.sources.bat.cli.run_daily_discovery")
+
+    cli.main(["discover", "--max-pages", "2"])
+
+    run_daily_discovery.assert_called_once_with(max_pages=2)
+
+
 @pytest.mark.parametrize("command", ["ingest", "transform", "load", "run"])
 def test_commands_require_listing_id(command, capsys):
     with pytest.raises(SystemExit) as exc_info:

--- a/tests/unit/bat/test_discover.py
+++ b/tests/unit/bat/test_discover.py
@@ -1,0 +1,285 @@
+import pytest
+
+from app.sources.bat import discover
+
+
+def test_parse_results_page_extracts_normalized_listing_ids_and_filters_unsupported():
+    html = """
+    <html>
+      <body>
+        <article class="auctions-item">
+          <a href="/listing/2004-bmw-m3/?utm_source=test">2004 BMW M3 Coupe</a>
+        </article>
+        <article class="auctions-item">
+          <a href="https://bringatrailer.com/listing/1972-honda-cb750/">1972 Honda CB750 Motorcycle</a>
+        </article>
+        <article class="auctions-item">
+          <a href="/listing/2004-bmw-m3/">Duplicate BMW Link</a>
+        </article>
+      </body>
+    </html>
+    """
+
+    listings = discover.parse_results_page(html)
+
+    assert listings == [
+        discover.DiscoveredListing(
+            source_listing_id="2004-bmw-m3",
+            url="https://bringatrailer.com/listing/2004-bmw-m3/",
+            eligible=True,
+            skip_reason=None,
+        ),
+        discover.DiscoveredListing(
+            source_listing_id="1972-honda-cb750",
+            url="https://bringatrailer.com/listing/1972-honda-cb750/",
+            eligible=False,
+            skip_reason="unsupported_listing_type",
+        ),
+    ]
+
+
+def test_parse_results_page_classifies_from_title_not_description_text():
+    html = """
+    <html>
+      <body>
+        <div class="listing-card">
+          <a class="image-overlay" href="/listing/2015-porsche-918-spyder/" title="2015 Porsche 918 Spyder"></a>
+          <h3><a href="/listing/2015-porsche-918-spyder/">2015 Porsche 918 Spyder</a></h3>
+          <div class="item-excerpt">
+            This car has center-lock wheels and a hybrid engine.
+          </div>
+        </div>
+      </body>
+    </html>
+    """
+
+    listings = discover.parse_results_page(html)
+
+    assert listings == [
+        discover.DiscoveredListing(
+            source_listing_id="2015-porsche-918-spyder",
+            url="https://bringatrailer.com/listing/2015-porsche-918-spyder/",
+            eligible=True,
+            skip_reason=None,
+        )
+    ]
+
+
+def test_normalize_listing_url_rejects_non_listing_urls():
+    with pytest.raises(ValueError, match="URL is not a BAT listing URL"):
+        discover.normalize_listing_url("https://bringatrailer.com/auctions/results/")
+
+
+def test_classify_listing_skips_ambiguous_records():
+    assert discover.classify_listing("No title metadata") == (
+        False,
+        "ambiguous_listing_type",
+    )
+
+
+def test_build_discovered_listing_params_maps_schema_columns():
+    listing = discover.DiscoveredListing(
+        source_listing_id="2004-bmw-m3",
+        url="https://bringatrailer.com/listing/2004-bmw-m3/",
+        eligible=True,
+    )
+
+    assert discover.build_discovered_listing_params(listing) == {
+        "source_site": "bringatrailer",
+        "source_listing_id": "2004-bmw-m3",
+        "url": "https://bringatrailer.com/listing/2004-bmw-m3/",
+        "eligible": True,
+        "skip_reason": None,
+    }
+
+
+def test_save_discovered_listings_upserts_and_returns_only_new_ids(mocker):
+    calls = {"executions": []}
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            calls["executions"].append((sql, params))
+
+        def fetchall(self):
+            return [("existing-listing",)]
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+    def fake_connect(database_url):
+        calls["database_url"] = database_url
+        return FakeConnection()
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    mocker.patch.object(discover.psycopg, "connect", side_effect=fake_connect)
+
+    new_ids = discover.save_discovered_listings(
+        [
+            discover.DiscoveredListing(
+                source_listing_id="new-listing",
+                url="https://bringatrailer.com/listing/new-listing/",
+                eligible=True,
+            ),
+            discover.DiscoveredListing(
+                source_listing_id="existing-listing",
+                url="https://bringatrailer.com/listing/existing-listing/",
+                eligible=True,
+            ),
+        ]
+    )
+
+    assert calls["database_url"] == "postgresql://user:pass@localhost/db"
+    assert new_ids == ["new-listing"]
+    select_sql, select_params = calls["executions"][0]
+    first_upsert_sql, first_upsert_params = calls["executions"][1]
+    assert "FROM discovered_listings" in select_sql
+    assert select_params == {
+        "source_site": "bringatrailer",
+        "source_listing_ids": ["new-listing", "existing-listing"],
+    }
+    assert "ON CONFLICT (source_site, source_listing_id) DO UPDATE" in first_upsert_sql
+    assert first_upsert_params["source_listing_id"] == "new-listing"
+
+
+def test_mark_discovered_listing_ingested_updates_ingested_at(mocker):
+    calls = {}
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            calls["sql"] = sql
+            calls["params"] = params
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    mocker.patch.object(discover.psycopg, "connect", return_value=FakeConnection())
+
+    discover.mark_discovered_listing_ingested("2004-bmw-m3")
+
+    assert "UPDATE discovered_listings" in calls["sql"]
+    assert "SET ingested_at = NOW()" in calls["sql"]
+    assert calls["params"] == {
+        "source_site": "bringatrailer",
+        "source_listing_id": "2004-bmw-m3",
+    }
+
+
+def test_discover_recent_listings_stops_after_first_page_with_no_new_ids():
+    fetched_urls = []
+
+    def fake_fetch_page(url):
+        fetched_urls.append(url)
+        return f"""
+        <article class="auction-card">
+          <a href="/listing/page-{len(fetched_urls)}-listing/">2004 BMW M3</a>
+        </article>
+        """
+
+    def fake_save_listings(listings):
+        if listings[0].source_listing_id == "page-2-listing":
+            return []
+        return [listing.source_listing_id for listing in listings]
+
+    result = discover.discover_recent_listings(
+        max_pages=5,
+        fetch_page=fake_fetch_page,
+        save_listings=fake_save_listings,
+    )
+
+    assert fetched_urls == [
+        "https://bringatrailer.com/auctions/results/",
+        "https://bringatrailer.com/auctions/results/?page=2",
+    ]
+    assert result == {
+        "discovered_count": 2,
+        "new_listing_ids": ["page-1-listing"],
+    }
+
+
+def test_discover_recent_listings_honors_max_pages():
+    fetched_urls = []
+
+    def fake_fetch_page(url):
+        fetched_urls.append(url)
+        return f"""
+        <article class="auction-card">
+          <a href="/listing/page-{len(fetched_urls)}-listing/">2004 BMW M3</a>
+        </article>
+        """
+
+    result = discover.discover_recent_listings(
+        max_pages=2,
+        fetch_page=fake_fetch_page,
+        save_listings=lambda listings: [listing.source_listing_id for listing in listings],
+    )
+
+    assert fetched_urls == [
+        "https://bringatrailer.com/auctions/results/",
+        "https://bringatrailer.com/auctions/results/?page=2",
+    ]
+    assert result["new_listing_ids"] == ["page-1-listing", "page-2-listing"]
+
+
+def test_ingest_pending_discovered_listings_fetches_only_loaded_pending_records(mocker):
+    pending = [
+        discover.DiscoveredListing(
+            source_listing_id="2004-bmw-m3",
+            url="https://bringatrailer.com/listing/2004-bmw-m3/",
+            eligible=True,
+        )
+    ]
+    fetch_listing_html = mocker.patch.object(discover, "fetch_listing_html", return_value="<html>listing</html>")
+    save_listing_html = mocker.patch.object(discover, "save_listing_html")
+    mark_ingested = mocker.patch.object(discover, "mark_discovered_listing_ingested")
+    transform_listing_html = mocker.patch.object(
+        discover,
+        "transform_listing_html",
+        return_value={"listing_id": "2004-bmw-m3"},
+    )
+    load_listing = mocker.patch.object(discover, "load_listing")
+
+    ingested_ids = discover.ingest_pending_discovered_listings(load_pending=lambda: pending)
+
+    assert ingested_ids == ["2004-bmw-m3"]
+    fetch_listing_html.assert_called_once_with("2004-bmw-m3")
+    save_listing_html.assert_called_once_with(
+        "2004-bmw-m3",
+        "<html>listing</html>",
+        "https://bringatrailer.com/listing/2004-bmw-m3/",
+    )
+    mark_ingested.assert_called_once_with("2004-bmw-m3")
+    transform_listing_html.assert_called_once_with("2004-bmw-m3")
+    load_listing.assert_called_once_with({"listing_id": "2004-bmw-m3"})


### PR DESCRIPTION
## Summary

- Adds Bring a Trailer completed-auction discovery from the results page.
- Persists discovered listing state in Postgres with eligibility, skip reason, created timestamp, and ingested timestamp.
- Adds a `discover --max-pages` CLI path that discovers recent listings and ingests eligible pending records through the existing raw HTML, transform, and load flow.
- Keeps existing single-listing `ingest`, `transform`, `load`, and `run` commands working.

## Validation

- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat` -> `87 passed`
- `.venv\Scripts\python.exe -m pytest -q tests\integration\test_postgres_schema.py` -> `1 passed`
- Live parser sanity check against `https://bringatrailer.com/auctions/results/` parsed 45 listings with no unsupported false positives in the first ten parsed listings.

## Notes

QA passed with documented residual risks around retry behavior after raw HTML save and future BaT markup/title changes.

Closes #50