### PR TITLE
[codex] Add discovered listings persistence

### DIFF
--- a/app/db/schema.sql
+++ b/app/db/schema.sql
@@ -32,3 +32,19 @@ CREATE TABLE IF NOT EXISTS raw_listing_html (
     processed BOOLEAN NOT NULL DEFAULT FALSE,
     UNIQUE (source_site, source_listing_id)
 );
+
+CREATE TABLE IF NOT EXISTS discovered_listings (
+    id BIGSERIAL PRIMARY KEY,
+    source_site TEXT NOT NULL,
+    source_listing_id TEXT NOT NULL,
+    url TEXT NOT NULL,
+    title TEXT,
+    auction_end_date DATE,
+    source_location TEXT,
+    eligible BOOLEAN,
+    eligibility_reason TEXT,
+    discovered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ingested_at TIMESTAMPTZ,
+    UNIQUE (source_site, source_listing_id)
+);

--- a/app/sources/bat/discovery.py
+++ b/app/sources/bat/discovery.py
@@ -1,0 +1,60 @@
+import logging
+import os
+
+import psycopg
+
+
+SOURCE_SITE = "bringatrailer"
+logger = logging.getLogger(__name__)
+
+
+UPSERT_DISCOVERED_LISTING_SQL = """
+INSERT INTO discovered_listings (
+    source_site,
+    source_listing_id,
+    url,
+    title,
+    auction_end_date,
+    source_location
+) VALUES (
+    %(source_site)s,
+    %(source_listing_id)s,
+    %(url)s,
+    %(title)s,
+    %(auction_end_date)s,
+    %(source_location)s
+)
+ON CONFLICT (source_site, source_listing_id) DO UPDATE SET
+    url = EXCLUDED.url,
+    title = EXCLUDED.title,
+    auction_end_date = EXCLUDED.auction_end_date,
+    source_location = EXCLUDED.source_location,
+    last_seen_at = NOW()
+"""
+
+
+def save_discovered_listing(candidate):
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set")
+
+    params = build_discovered_listing_params(candidate)
+
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(UPSERT_DISCOVERED_LISTING_SQL, params)
+            logger.info(
+                "Upserted BAT discovered listing for listing_id=%s",
+                params["source_listing_id"],
+            )
+
+
+def build_discovered_listing_params(candidate):
+    return {
+        "source_site": SOURCE_SITE,
+        "source_listing_id": candidate["listing_id"],
+        "url": candidate["url"],
+        "title": candidate.get("title"),
+        "auction_end_date": candidate.get("auction_end_date"),
+        "source_location": candidate.get("source_location"),
+    }

--- a/tests/integration/test_postgres_schema.py
+++ b/tests/integration/test_postgres_schema.py
@@ -135,6 +135,162 @@ def test_schema_sql_applies_in_isolated_postgres_container():
             """,
         )
         assert raw_defaults == ["false|t"]
+
+        discovered_column_rows = _psql(
+            container_name,
+            """
+            SELECT column_name || ':' || data_type || ':' || is_nullable
+            FROM information_schema.columns
+            WHERE table_name = 'discovered_listings'
+              AND column_name IN (
+                  'id',
+                  'source_site',
+                  'source_listing_id',
+                  'url',
+                  'title',
+                  'auction_end_date',
+                  'source_location',
+                  'eligible',
+                  'eligibility_reason',
+                  'discovered_at',
+                  'last_seen_at',
+                  'ingested_at'
+              )
+            ORDER BY column_name;
+            """,
+        )
+        assert discovered_column_rows == [
+            "auction_end_date:date:YES",
+            "discovered_at:timestamp with time zone:NO",
+            "eligibility_reason:text:YES",
+            "eligible:boolean:YES",
+            "id:bigint:NO",
+            "ingested_at:timestamp with time zone:YES",
+            "last_seen_at:timestamp with time zone:NO",
+            "source_listing_id:text:NO",
+            "source_location:text:YES",
+            "source_site:text:NO",
+            "title:text:YES",
+            "url:text:NO",
+        ]
+
+        discovered_unique_columns = _psql(
+            container_name,
+            """
+            SELECT string_agg(a.attname, ',' ORDER BY array_position(c.conkey, a.attnum))
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(c.conkey)
+            WHERE t.relname = 'discovered_listings'
+              AND c.contype = 'u'
+            GROUP BY c.oid;
+            """,
+        )
+        assert "source_site,source_listing_id" in discovered_unique_columns
+
+        discovered_defaults = _psql(
+            container_name,
+            """
+            WITH inserted AS (
+                INSERT INTO discovered_listings (
+                    source_site,
+                    source_listing_id,
+                    url
+                ) VALUES (
+                    'bringatrailer',
+                    'schema-discovery-test',
+                    'https://bringatrailer.com/listing/schema-discovery-test/'
+                )
+                RETURNING
+                    title,
+                    auction_end_date,
+                    source_location,
+                    eligible,
+                    eligibility_reason,
+                    discovered_at,
+                    last_seen_at,
+                    ingested_at
+            )
+            SELECT
+                title IS NULL,
+                auction_end_date IS NULL,
+                source_location IS NULL,
+                eligible IS NULL,
+                eligibility_reason IS NULL,
+                discovered_at IS NOT NULL,
+                last_seen_at IS NOT NULL,
+                ingested_at IS NULL
+            FROM inserted;
+            """,
+        )
+        assert discovered_defaults == ["t|t|t|t|t|t|t|t"]
+
+        discovered_upsert = _psql(
+            container_name,
+            """
+            WITH original AS (
+                SELECT discovered_at
+                FROM discovered_listings
+                WHERE source_site = 'bringatrailer'
+                  AND source_listing_id = 'schema-discovery-test'
+            ),
+            upserted AS (
+                INSERT INTO discovered_listings (
+                    source_site,
+                    source_listing_id,
+                    url,
+                    title,
+                    auction_end_date,
+                    source_location
+                ) VALUES (
+                    'bringatrailer',
+                    'schema-discovery-test',
+                    'https://bringatrailer.com/listing/schema-discovery-test-updated/',
+                    'Updated title',
+                    '2026-03-30',
+                    'CAN'
+                )
+                ON CONFLICT (source_site, source_listing_id) DO UPDATE SET
+                    url = EXCLUDED.url,
+                    title = EXCLUDED.title,
+                    auction_end_date = EXCLUDED.auction_end_date,
+                    source_location = EXCLUDED.source_location,
+                    last_seen_at = NOW()
+                RETURNING
+                    id,
+                    url,
+                    title,
+                    auction_end_date,
+                    source_location,
+                    discovered_at,
+                    last_seen_at,
+                    eligible,
+                    eligibility_reason,
+                    ingested_at
+            )
+            SELECT
+                (SELECT COUNT(*) FROM discovered_listings
+                 WHERE source_site = 'bringatrailer'
+                   AND source_listing_id = 'schema-discovery-test'),
+                url,
+                title,
+                auction_end_date,
+                source_location,
+                upserted.discovered_at = original.discovered_at,
+                upserted.last_seen_at >= original.discovered_at,
+                eligible IS NULL,
+                eligibility_reason IS NULL,
+                ingested_at IS NULL
+            FROM upserted
+            CROSS JOIN original;
+            """,
+        )
+        assert discovered_upsert == [
+            (
+                "1|https://bringatrailer.com/listing/schema-discovery-test-updated/"
+                "|Updated title|2026-03-30|CAN|t|t|t|t|t"
+            )
+        ]
     finally:
         subprocess.run(["docker", "rm", "-f", container_name], capture_output=True, text=True)
 

--- a/tests/unit/bat/test_discovery.py
+++ b/tests/unit/bat/test_discovery.py
@@ -1,0 +1,115 @@
+import logging
+
+import pytest
+
+from app.sources.bat import discovery
+
+
+def test_build_discovered_listing_params_maps_candidate_to_schema_columns():
+    params = discovery.build_discovered_listing_params(_candidate())
+
+    assert params == {
+        "source_site": "bringatrailer",
+        "source_listing_id": "test-listing",
+        "url": "https://bringatrailer.com/listing/test-listing/",
+        "title": "2004 BMW M3 Coupe",
+        "auction_end_date": "2026-03-30",
+        "source_location": "USA",
+    }
+
+
+def test_build_discovered_listing_params_allows_missing_visible_metadata():
+    params = discovery.build_discovered_listing_params(
+        {
+            "listing_id": "test-listing",
+            "url": "https://bringatrailer.com/listing/test-listing/",
+        }
+    )
+
+    assert params == {
+        "source_site": "bringatrailer",
+        "source_listing_id": "test-listing",
+        "url": "https://bringatrailer.com/listing/test-listing/",
+        "title": None,
+        "auction_end_date": None,
+        "source_location": None,
+    }
+
+
+def test_save_discovered_listing_executes_upsert_for_visible_metadata(mocker, caplog):
+    calls = {"executions": []}
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            calls["executions"].append((sql, params))
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+    def fake_connect(database_url):
+        calls["database_url"] = database_url
+        return FakeConnection()
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    mocker.patch.object(discovery.psycopg, "connect", side_effect=fake_connect)
+
+    caplog.set_level(logging.INFO)
+    discovery.save_discovered_listing(_candidate())
+
+    sql, params = calls["executions"][0]
+
+    assert calls["database_url"] == "postgresql://user:pass@localhost/db"
+    assert "INSERT INTO discovered_listings" in sql
+    assert "ON CONFLICT (source_site, source_listing_id) DO UPDATE" in sql
+    assert "url = EXCLUDED.url" in sql
+    assert "title = EXCLUDED.title" in sql
+    assert "auction_end_date = EXCLUDED.auction_end_date" in sql
+    assert "source_location = EXCLUDED.source_location" in sql
+    assert "last_seen_at = NOW()" in sql
+    assert "eligible" not in sql
+    assert "eligibility_reason" not in sql
+    assert "ingested_at" not in sql
+    assert "discovered_at" not in sql
+    assert params == {
+        "source_site": "bringatrailer",
+        "source_listing_id": "test-listing",
+        "url": "https://bringatrailer.com/listing/test-listing/",
+        "title": "2004 BMW M3 Coupe",
+        "auction_end_date": "2026-03-30",
+        "source_location": "USA",
+    }
+    assert "Upserted BAT discovered listing for listing_id=test-listing" in caplog.text
+    assert "postgresql://user:pass@localhost/db" not in caplog.text
+
+
+def test_save_discovered_listing_requires_database_url(mocker):
+    mocker.patch.dict("os.environ", {}, clear=True)
+
+    with pytest.raises(RuntimeError, match="DATABASE_URL must be set"):
+        discovery.save_discovered_listing(_candidate())
+
+
+def _candidate():
+    return {
+        "listing_id": "test-listing",
+        "url": "https://bringatrailer.com/listing/test-listing/",
+        "title": "2004 BMW M3 Coupe",
+        "auction_end_date": "2026-03-30",
+        "source_location": "USA",
+    }


### PR DESCRIPTION
## Summary

- Add a `discovered_listings` table with idempotent uniqueness on `(source_site, source_listing_id)`.
- Add BAT discovery persistence helpers that upsert listing URL, title, auction end date, source location, and `last_seen_at` without touching future eligibility or ingest state.
- Add focused unit tests and extend the Postgres schema integration test for the new table contract.

## Validation

```powershell
.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_discovery.py tests\integration\test_postgres_schema.py
```

Result: `4 passed, 1 skipped`.

The skipped test was the Docker-backed schema integration test because the local Docker daemon was unavailable.