### PR TITLE
[codex] Parse completed BAT auction cards

### DIFF
--- a/app/sources/bat/discovery.py
+++ b/app/sources/bat/discovery.py
@@ -1,10 +1,16 @@
 import logging
 import os
+import re
+from datetime import datetime
+from urllib.parse import urljoin, urlparse
 
+from bs4 import BeautifulSoup
 import psycopg
 
 
 SOURCE_SITE = "bringatrailer"
+BASE_URL = "https://bringatrailer.com"
+COMPLETED_AUCTIONS_SECTION_TITLE = "All Completed Auctions"
 logger = logging.getLogger(__name__)
 
 
@@ -33,6 +39,43 @@ ON CONFLICT (source_site, source_listing_id) DO UPDATE SET
 """
 
 
+def parse_completed_auction_candidates(html, max_candidates=None):
+    if max_candidates is not None and max_candidates <= 0:
+        return []
+
+    soup = BeautifulSoup(html, "html.parser")
+    heading = _find_completed_auctions_heading(soup)
+    if heading is None:
+        return []
+
+    candidates = []
+    seen_listing_ids = set()
+
+    for link in _iter_completed_auction_links(heading):
+        normalized = _normalize_listing_href(link.get("href"))
+        if normalized is None:
+            continue
+
+        listing_id, url = normalized
+        if listing_id in seen_listing_ids:
+            continue
+
+        seen_listing_ids.add(listing_id)
+        candidate = {
+            "source_site": SOURCE_SITE,
+            "listing_id": listing_id,
+            "source_listing_id": listing_id,
+            "url": url,
+        }
+        candidate.update(_extract_card_metadata(link))
+        candidates.append(candidate)
+
+        if max_candidates is not None and len(candidates) >= max_candidates:
+            break
+
+    return candidates
+
+
 def save_discovered_listing(candidate):
     database_url = os.environ.get("DATABASE_URL")
     if not database_url:
@@ -58,3 +101,103 @@ def build_discovered_listing_params(candidate):
         "auction_end_date": candidate.get("auction_end_date"),
         "source_location": candidate.get("source_location"),
     }
+
+
+def _find_completed_auctions_heading(soup):
+    for tag in soup.find_all(True):
+        if _normalized_text(tag) == COMPLETED_AUCTIONS_SECTION_TITLE:
+            return tag
+    return None
+
+
+def _iter_completed_auction_links(heading):
+    for element in heading.next_elements:
+        if element is heading:
+            continue
+        if not getattr(element, "name", None):
+            continue
+        if (
+            element.name == "a"
+            and element.get("href")
+            and _is_listing_card_link(element)
+        ):
+            yield element
+
+
+def _is_listing_card_link(element):
+    return "listing-card" in element.get("class", [])
+
+
+def _normalize_listing_href(href):
+    if not href:
+        return None
+
+    parsed = urlparse(urljoin(BASE_URL, href))
+    if parsed.netloc and parsed.netloc.lower() != "bringatrailer.com":
+        return None
+
+    match = re.fullmatch(r"/listing/([^/]+)/?", parsed.path)
+    if match is None:
+        return None
+
+    listing_id = match.group(1)
+    return listing_id, f"{BASE_URL}/listing/{listing_id}/"
+
+
+def _extract_card_metadata(card):
+    metadata = {}
+
+    title = _extract_title(card)
+    if title:
+        metadata["title"] = title
+
+    auction_end_date = _extract_auction_end_date(card)
+    if auction_end_date:
+        metadata["auction_end_date"] = auction_end_date
+
+    source_location = _extract_source_location(card)
+    if source_location:
+        metadata["source_location"] = source_location
+
+    return metadata
+
+
+def _extract_title(card):
+    title = card.select_one(".content-main h3")
+    if title is None:
+        return None
+    return _normalized_text(title) or None
+
+
+def _extract_auction_end_date(card):
+    result = card.select_one(".content-main .item-results")
+    if result is None:
+        return None
+    return _parse_date(_normalized_text(result))
+
+
+def _extract_source_location(card):
+    location = card.select_one(".content-main .show-country-name")
+    if location is None:
+        return None
+    return _normalized_text(location) or None
+
+
+def _parse_date(value):
+    if not value:
+        return None
+
+    text = str(value).strip()
+    iso_match = re.search(r"\d{4}-\d{2}-\d{2}", text)
+    if iso_match:
+        return iso_match.group(0)
+
+    numeric_match = re.search(r"\d{1,2}/\d{1,2}/\d{4}", text)
+    if numeric_match is None:
+        return None
+
+    return datetime.strptime(numeric_match.group(0), "%m/%d/%Y").date().isoformat()
+
+
+def _normalized_text(tag):
+    return " ".join(tag.get_text(" ", strip=True).split())

--- a/tests/unit/bat/test_discovery.py
+++ b/tests/unit/bat/test_discovery.py
@@ -1,8 +1,177 @@
 import logging
+from pathlib import Path
 
 import pytest
 
 from app.sources.bat import discovery
+
+FIXTURES_DIR = Path(__file__).parents[2] / "fixtures"
+
+
+def test_parse_completed_auction_candidates_returns_normalized_unique_candidates():
+    candidates = discovery.parse_completed_auction_candidates(_results_html())
+
+    assert candidates == [
+        {
+            "source_site": "bringatrailer",
+            "listing_id": "newest-car",
+            "source_listing_id": "newest-car",
+            "url": "https://bringatrailer.com/listing/newest-car/",
+            "title": "1995 Porsche 911 Carrera Coupe",
+            "auction_end_date": "2026-04-19",
+            "source_location": "USA",
+        },
+        {
+            "source_site": "bringatrailer",
+            "listing_id": "older-car",
+            "source_listing_id": "older-car",
+            "url": "https://bringatrailer.com/listing/older-car/",
+            "title": "2004 BMW M3 Coupe",
+            "auction_end_date": "2026-04-18",
+            "source_location": "CAN",
+        },
+    ]
+
+
+def test_parse_completed_auction_candidates_starts_at_completed_auctions_section():
+    candidates = discovery.parse_completed_auction_candidates(
+        """
+        <main>
+            <h2>This Week's Popular Listings</h2>
+            <article>
+                <a href="/listing/popular-listing/">Popular listing</a>
+            </article>
+            <h2>Selected Market Results</h2>
+            <article>
+                <a href="/listing/market-result/">Market result</a>
+            </article>
+            <h2>Recent Exceptional Results</h2>
+            <a class="listing-card" href="/listing/exceptional-result/">
+                <h3>Exceptional result</h3>
+            </a>
+            <h2>All Completed Auctions</h2>
+            <a class="listing-card" href="/listing/target-listing/">
+                <h3>Target listing</h3>
+            </a>
+        </main>
+        """
+    )
+
+    assert [candidate["listing_id"] for candidate in candidates] == ["target-listing"]
+
+
+def test_parse_completed_auction_candidates_ignores_non_listing_links():
+    candidates = discovery.parse_completed_auction_candidates(
+        """
+        <main>
+            <h2>All Completed Auctions</h2>
+            <nav>
+                <a href="/">Home</a>
+                <a href="/auctions/">Auctions</a>
+                <a href="/search/?q=porsche">Search</a>
+                <a href="/parts/air-cooled-sign/">Parts</a>
+                <a href="/model/porsche-911/">Model market</a>
+                <a href="https://example.com/listing/not-bat/">External</a>
+                <a href="/listing/not-a-card/">Not a card</a>
+            </nav>
+            <a class="listing-card" href="/listing/real-listing/">
+                <h3>Real listing</h3>
+            </a>
+        </main>
+        """
+    )
+
+    assert [candidate["listing_id"] for candidate in candidates] == ["real-listing"]
+
+
+def test_parse_completed_auction_candidates_applies_max_after_normalization():
+    candidates = discovery.parse_completed_auction_candidates(
+        _results_html(), max_candidates=1
+    )
+
+    assert [candidate["listing_id"] for candidate in candidates] == ["newest-car"]
+
+
+def test_parse_completed_auction_candidates_allows_missing_metadata():
+    candidates = discovery.parse_completed_auction_candidates(
+        """
+        <main>
+            <h2>All Completed Auctions</h2>
+            <a class="listing-card" href="/listing/no-metadata/">View listing</a>
+        </main>
+        """
+    )
+
+    assert candidates == [
+        {
+            "source_site": "bringatrailer",
+            "listing_id": "no-metadata",
+            "source_listing_id": "no-metadata",
+            "url": "https://bringatrailer.com/listing/no-metadata/",
+        }
+    ]
+
+
+def test_parse_completed_auction_candidates_returns_empty_without_target_section():
+    candidates = discovery.parse_completed_auction_candidates(
+        """
+        <main>
+            <h2>This Week's Popular Listings</h2>
+            <article>
+                <a href="/listing/popular-listing/">Popular listing</a>
+            </article>
+        </main>
+        """
+    )
+
+    assert candidates == []
+
+
+def test_parse_completed_auction_candidates_ignores_json_initial_data_only():
+    candidates = discovery.parse_completed_auction_candidates(
+        """
+        <main>
+            <h2>All Completed Auctions</h2>
+            <script id="bat-theme-auctions-completed-initial-data">
+                var auctionsCompletedInitialData = {
+                    "items": [
+                        {
+                            "title": "JSON-only listing",
+                            "url": "https://bringatrailer.com/listing/json-only/"
+                        }
+                    ]
+                };
+            </script>
+        </main>
+        """
+    )
+
+    assert candidates == []
+
+
+def test_parse_completed_auction_candidates_reads_rendered_card_fixture():
+    card = (FIXTURES_DIR / "card.html").read_text(encoding="utf-8")
+
+    candidates = discovery.parse_completed_auction_candidates(
+        f"""
+        <main>
+            <h2>All Completed Auctions</h2>
+            {card}
+        </main>
+        """
+    )
+
+    assert candidates == [
+        {
+            "source_site": "bringatrailer",
+            "listing_id": "1958-gmc-pickup-7",
+            "source_listing_id": "1958-gmc-pickup-7",
+            "url": "https://bringatrailer.com/listing/1958-gmc-pickup-7/",
+            "title": "1958 GMC 9310 Stepside Pickup 3-Speed",
+            "auction_end_date": "2026-04-20",
+            "source_location": "CAN",
+        }
+    ]
 
 
 def test_build_discovered_listing_params_maps_candidate_to_schema_columns():
@@ -113,3 +282,36 @@ def _candidate():
         "auction_end_date": "2026-03-30",
         "source_location": "USA",
     }
+
+
+def _results_html():
+    return """
+    <main>
+        <section>
+            <h2>All Completed Auctions</h2>
+            <a class="listing-card" href="/listing/newest-car/?utm_source=feed">
+                <div class="content-main">
+                    <h3>1995 Porsche 911 Carrera Coupe</h3>
+                    <span class="show-country-name">USA</span>
+                    <div class="item-results">
+                        Sold for USD $19,911 <span> on 04/19/2026 </span>
+                    </div>
+                </div>
+            </a>
+            <a class="listing-card" href="https://bringatrailer.com/listing/newest-car#comments">
+                <div class="content-main">
+                    <h3>Duplicate link</h3>
+                </div>
+            </a>
+            <a class="listing-card" href="https://bringatrailer.com/listing/older-car/">
+                <div class="content-main">
+                    <h3>2004 BMW M3 Coupe</h3>
+                    <span class="show-country-name">CAN</span>
+                    <div class="item-results">
+                        Bid to USD $30,000 <span> on 04/18/2026 </span>
+                    </div>
+                </div>
+            </a>
+        </section>
+    </main>
+    """


### PR DESCRIPTION
## Summary

- Add BAT discovery parsing for rendered `All Completed Auctions` listing cards.
- Normalize `/listing/<slug>/` URLs into canonical candidate records with source IDs.
- Extract title, auction end date, and country/location from the rendered card structure.
- Add focused unit coverage for rendered card parsing, duplicate normalization, non-card links, JSON-only initial data, and section anchoring.

## Notes

- The parser intentionally ignores `bat-theme-auctions-completed-initial-data` because it only reflects the initially returned page of results.
- No Postgres schema, CLI behavior, raw HTML ingestion, transform, or load behavior changed.

## Verification

- User reported their test run passed after the final metadata refactor.
- Prior local verification before the final refactor passed with `93 passed`; final refactor was not rerun locally at the user's request before approval.