### PR TITLE
[codex] Add BAT discovery command

### DIFF
--- a/app/sources/bat/cli.py
+++ b/app/sources/bat/cli.py
@@ -1,8 +1,10 @@
 import argparse
 import logging
+from datetime import date
 
 from dotenv import load_dotenv
 
+from app.sources.bat.discovery import discover_completed_auctions
 from app.sources.bat.ingest import fetch_listing_html, save_listing_html
 from app.sources.bat.load import load_listing
 from app.sources.bat.transform import transform_listing_html
@@ -19,6 +21,18 @@ def build_parser():
     for command in ("ingest", "transform", "load", "run"):
         subparser = subparsers.add_parser(command)
         subparser.add_argument("--listing-id", required=True)
+
+    discover_parser = subparsers.add_parser("discover")
+    discover_parser.add_argument(
+        "--results-url",
+        default="https://bringatrailer.com/auctions/results/",
+    )
+    discover_parser.add_argument(
+        "--scrape-date",
+        type=date.fromisoformat,
+        default=date.today(),
+    )
+    discover_parser.add_argument("--max-candidates", type=int)
 
     return parser
 
@@ -50,12 +64,53 @@ def run_listing(listing_id):
     load_listing(transformed_listing)
 
 
+def discover_listings(results_url, scrape_date, max_candidates=None):
+    return discover_completed_auctions(
+        results_url=results_url,
+        scrape_date=scrape_date,
+        max_candidates=max_candidates,
+    )
+
+
 def main(argv=None):
     configure_logging()
     args = build_parser().parse_args(argv)
 
-    logger.info("BAT %s command started for listing_id=%s", args.command, args.listing_id)
     try:
+        if args.command == "discover":
+            logger.info(
+                "BAT discover command started for results_url=%s scrape_date=%s max_candidates=%s",
+                args.results_url,
+                args.scrape_date.isoformat(),
+                args.max_candidates,
+            )
+            summary = discover_listings(
+                results_url=args.results_url,
+                scrape_date=args.scrape_date,
+                max_candidates=args.max_candidates,
+            )
+            logger.info(
+                "BAT discover summary inspected=%s new=%s existing_or_updated=%s failed=%s",
+                summary.candidates_inspected,
+                summary.newly_discovered,
+                summary.already_discovered_or_updated,
+                summary.failed,
+            )
+            print(
+                "Discovery summary: "
+                f"inspected={summary.candidates_inspected} "
+                f"new={summary.newly_discovered} "
+                f"existing_or_updated={summary.already_discovered_or_updated} "
+                f"failed={summary.failed}"
+            )
+            logger.info(
+                "BAT discover command completed for results_url=%s scrape_date=%s",
+                args.results_url,
+                args.scrape_date.isoformat(),
+            )
+            return
+
+        logger.info("BAT %s command started for listing_id=%s", args.command, args.listing_id)
         if args.command == "ingest":
             ingest_listing(args.listing_id)
         elif args.command == "transform":
@@ -65,7 +120,14 @@ def main(argv=None):
         elif args.command == "run":
             run_listing(args.listing_id)
     except Exception:
-        logger.error("BAT %s command failed for listing_id=%s", args.command, args.listing_id)
+        if args.command == "discover":
+            logger.error(
+                "BAT discover command failed for results_url=%s scrape_date=%s",
+                args.results_url,
+                args.scrape_date.isoformat(),
+            )
+        else:
+            logger.error("BAT %s command failed for listing_id=%s", args.command, args.listing_id)
         raise
     logger.info("BAT %s command completed for listing_id=%s", args.command, args.listing_id)
 

--- a/app/sources/bat/discovery.py
+++ b/app/sources/bat/discovery.py
@@ -1,11 +1,13 @@
 import logging
 import os
 import re
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import date, datetime
 from urllib.parse import urljoin, urlparse
 
 from bs4 import BeautifulSoup
 import psycopg
+import requests
 
 
 SOURCE_SITE = "bringatrailer"
@@ -36,7 +38,16 @@ ON CONFLICT (source_site, source_listing_id) DO UPDATE SET
     auction_end_date = EXCLUDED.auction_end_date,
     source_location = EXCLUDED.source_location,
     last_seen_at = NOW()
+RETURNING xmax = 0 AS inserted
 """
+
+
+@dataclass
+class DiscoverySummary:
+    candidates_inspected: int = 0
+    newly_discovered: int = 0
+    already_discovered_or_updated: int = 0
+    failed: int = 0
 
 
 def parse_completed_auction_candidates(html, max_candidates=None):
@@ -76,6 +87,57 @@ def parse_completed_auction_candidates(html, max_candidates=None):
     return candidates
 
 
+def fetch_completed_auctions_results(results_url):
+    logger.info("Fetching BAT completed auctions results from url=%s", results_url)
+    response = requests.get(results_url, timeout=10)
+    response.raise_for_status()
+    logger.info("Fetched BAT completed auctions results from url=%s", results_url)
+    return response.text
+
+
+def discover_completed_auctions(results_url, scrape_date, max_candidates=None):
+    normalized_scrape_date = _normalize_scrape_date(scrape_date)
+    html = fetch_completed_auctions_results(results_url)
+    candidates = parse_completed_auction_candidates(html, max_candidates=max_candidates)
+    summary = DiscoverySummary()
+
+    for candidate in candidates:
+        summary.candidates_inspected += 1
+        listing_id = candidate["listing_id"]
+        auction_end_date = candidate.get("auction_end_date")
+
+        if not auction_end_date:
+            summary.failed += 1
+            logger.error(
+                "Failed BAT discovery candidate for listing_id=%s because auction_end_date is missing",
+                listing_id,
+            )
+            continue
+
+        if date.fromisoformat(auction_end_date) < normalized_scrape_date:
+            logger.info(
+                "Stopping BAT discovery at listing_id=%s because auction_end_date=%s is older than scrape_date=%s",
+                listing_id,
+                auction_end_date,
+                normalized_scrape_date.isoformat(),
+            )
+            break
+
+        try:
+            if save_discovered_listing(candidate):
+                summary.newly_discovered += 1
+            else:
+                summary.already_discovered_or_updated += 1
+        except Exception:
+            summary.failed += 1
+            logger.error(
+                "Failed BAT discovery candidate for listing_id=%s",
+                listing_id,
+            )
+
+    return summary
+
+
 def save_discovered_listing(candidate):
     database_url = os.environ.get("DATABASE_URL")
     if not database_url:
@@ -86,10 +148,12 @@ def save_discovered_listing(candidate):
     with psycopg.connect(database_url) as conn:
         with conn.cursor() as cur:
             cur.execute(UPSERT_DISCOVERED_LISTING_SQL, params)
+            inserted, = cur.fetchone()
             logger.info(
                 "Upserted BAT discovered listing for listing_id=%s",
                 params["source_listing_id"],
             )
+            return inserted
 
 
 def build_discovered_listing_params(candidate):
@@ -101,6 +165,16 @@ def build_discovered_listing_params(candidate):
         "auction_end_date": candidate.get("auction_end_date"),
         "source_location": candidate.get("source_location"),
     }
+
+
+def _normalize_scrape_date(value):
+    if isinstance(value, date):
+        return value
+
+    if isinstance(value, str):
+        return date.fromisoformat(value)
+
+    raise TypeError("scrape_date must be a date or ISO date string")
 
 
 def _find_completed_auctions_heading(soup):

--- a/tests/unit/bat/test_cli.py
+++ b/tests/unit/bat/test_cli.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import date
 
 import pytest
 
@@ -94,6 +95,83 @@ def test_run_command_executes_ingest_transform_load_in_order(mocker):
         ("transform", "test-id"),
         ("load", transformed_listing),
     ]
+
+
+def test_discover_command_parses_without_listing_id():
+    args = cli.build_parser().parse_args(["discover"])
+
+    assert args.command == "discover"
+    assert args.results_url == "https://bringatrailer.com/auctions/results/"
+    assert args.max_candidates is None
+    assert isinstance(args.scrape_date, date)
+
+
+def test_discover_command_dispatches_with_parsed_options(mocker, caplog, capsys):
+    discover_completed_auctions = mocker.patch(
+        "app.sources.bat.cli.discover_completed_auctions",
+        return_value=mocker.Mock(
+            candidates_inspected=2,
+            newly_discovered=1,
+            already_discovered_or_updated=1,
+            failed=0,
+        ),
+    )
+
+    caplog.set_level(logging.INFO)
+    cli.main(
+        [
+            "discover",
+            "--results-url",
+            "https://bringatrailer.com/auctions/results/page/2/",
+            "--scrape-date",
+            "2026-04-20",
+            "--max-candidates",
+            "5",
+        ]
+    )
+
+    discover_completed_auctions.assert_called_once_with(
+        results_url="https://bringatrailer.com/auctions/results/page/2/",
+        scrape_date=date(2026, 4, 20),
+        max_candidates=5,
+    )
+    assert (
+        "BAT discover command started for results_url=https://bringatrailer.com/auctions/results/page/2/ "
+        "scrape_date=2026-04-20 max_candidates=5"
+    ) in caplog.text
+    assert "BAT discover summary inspected=2 new=1 existing_or_updated=1 failed=0" in caplog.text
+    assert (
+        "BAT discover command completed for results_url=https://bringatrailer.com/auctions/results/page/2/ "
+        "scrape_date=2026-04-20"
+    ) in caplog.text
+    assert (
+        "Discovery summary: inspected=2 new=1 existing_or_updated=1 failed=0"
+        in capsys.readouterr().out
+    )
+
+
+def test_discover_command_logs_failure_context_without_traceback_and_reraises(mocker, caplog):
+    error = RuntimeError("discover failed")
+    mocker.patch(
+        "app.sources.bat.cli.discover_completed_auctions",
+        side_effect=error,
+    )
+
+    caplog.set_level(logging.INFO)
+    with pytest.raises(RuntimeError) as exc_info:
+        cli.main(["discover", "--scrape-date", "2026-04-20"])
+
+    assert exc_info.value is error
+    assert (
+        "BAT discover command started for results_url=https://bringatrailer.com/auctions/results/ "
+        "scrape_date=2026-04-20 max_candidates=None"
+    ) in caplog.text
+    assert (
+        "BAT discover command failed for results_url=https://bringatrailer.com/auctions/results/ "
+        "scrape_date=2026-04-20"
+    ) in caplog.text
+    assert "Traceback" not in caplog.text
+    assert "RuntimeError: discover failed" not in caplog.text
 
 
 @pytest.mark.parametrize("command", ["ingest", "transform", "load", "run"])

--- a/tests/unit/bat/test_discovery.py
+++ b/tests/unit/bat/test_discovery.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -174,6 +175,170 @@ def test_parse_completed_auction_candidates_reads_rendered_card_fixture():
     ]
 
 
+def test_fetch_completed_auctions_results_uses_url_and_timeout(mocker, caplog):
+    response = mocker.Mock()
+    response.text = "<html>Results</html>"
+    response.raise_for_status = mocker.Mock()
+    mock_get = mocker.patch("app.sources.bat.discovery.requests.get", return_value=response)
+
+    caplog.set_level(logging.INFO)
+    html = discovery.fetch_completed_auctions_results(
+        "https://bringatrailer.com/auctions/results/"
+    )
+
+    assert html == "<html>Results</html>"
+    mock_get.assert_called_once_with(
+        "https://bringatrailer.com/auctions/results/",
+        timeout=10,
+    )
+    response.raise_for_status.assert_called_once_with()
+    assert "Fetching BAT completed auctions results from url=https://bringatrailer.com/auctions/results/" in caplog.text
+    assert "Fetched BAT completed auctions results from url=https://bringatrailer.com/auctions/results/" in caplog.text
+
+
+def test_discover_completed_auctions_returns_summary_counts(mocker):
+    mocker.patch(
+        "app.sources.bat.discovery.fetch_completed_auctions_results",
+        return_value="<html>Results</html>",
+    )
+    mocker.patch(
+        "app.sources.bat.discovery.parse_completed_auction_candidates",
+        return_value=[
+            {
+                "listing_id": "new-car",
+                "url": "https://bringatrailer.com/listing/new-car/",
+                "auction_end_date": "2026-04-20",
+            },
+            {
+                "listing_id": "existing-car",
+                "url": "https://bringatrailer.com/listing/existing-car/",
+                "auction_end_date": "2026-04-20",
+            },
+            {
+                "listing_id": "broken-car",
+                "url": "https://bringatrailer.com/listing/broken-car/",
+                "auction_end_date": "2026-04-20",
+            },
+        ],
+    )
+    save_discovered_listing = mocker.patch(
+        "app.sources.bat.discovery.save_discovered_listing",
+        side_effect=[True, False, RuntimeError("boom")],
+    )
+
+    summary = discovery.discover_completed_auctions(
+        results_url="https://bringatrailer.com/auctions/results/",
+        scrape_date=date(2026, 4, 20),
+        max_candidates=3,
+    )
+
+    assert summary == discovery.DiscoverySummary(
+        candidates_inspected=3,
+        newly_discovered=1,
+        already_discovered_or_updated=1,
+        failed=1,
+    )
+    assert save_discovered_listing.call_count == 3
+
+
+def test_discover_completed_auctions_stops_when_candidate_is_older_than_scrape_date(mocker):
+    mocker.patch(
+        "app.sources.bat.discovery.fetch_completed_auctions_results",
+        return_value="<html>Results</html>",
+    )
+    mocker.patch(
+        "app.sources.bat.discovery.parse_completed_auction_candidates",
+        return_value=[
+            {
+                "listing_id": "newest-car",
+                "url": "https://bringatrailer.com/listing/newest-car/",
+                "auction_end_date": "2026-04-20",
+            },
+            {
+                "listing_id": "same-day-car",
+                "url": "https://bringatrailer.com/listing/same-day-car/",
+                "auction_end_date": "2026-04-20",
+            },
+            {
+                "listing_id": "older-car",
+                "url": "https://bringatrailer.com/listing/older-car/",
+                "auction_end_date": "2026-04-19",
+            },
+            {
+                "listing_id": "oldest-car",
+                "url": "https://bringatrailer.com/listing/oldest-car/",
+                "auction_end_date": "2026-04-18",
+            },
+        ],
+    )
+    save_discovered_listing = mocker.patch(
+        "app.sources.bat.discovery.save_discovered_listing",
+        return_value=True,
+    )
+
+    summary = discovery.discover_completed_auctions(
+        results_url="https://bringatrailer.com/auctions/results/",
+        scrape_date="2026-04-20",
+    )
+
+    assert summary == discovery.DiscoverySummary(
+        candidates_inspected=3,
+        newly_discovered=2,
+        already_discovered_or_updated=0,
+        failed=0,
+    )
+    assert [call.args[0]["listing_id"] for call in save_discovered_listing.call_args_list] == [
+        "newest-car",
+        "same-day-car",
+    ]
+
+
+def test_discover_completed_auctions_marks_missing_auction_end_date_as_failed(mocker):
+    mocker.patch(
+        "app.sources.bat.discovery.fetch_completed_auctions_results",
+        return_value="<html>Results</html>",
+    )
+    mocker.patch(
+        "app.sources.bat.discovery.parse_completed_auction_candidates",
+        return_value=[
+            {
+                "listing_id": "missing-date",
+                "url": "https://bringatrailer.com/listing/missing-date/",
+            },
+            {
+                "listing_id": "in-scope",
+                "url": "https://bringatrailer.com/listing/in-scope/",
+                "auction_end_date": "2026-04-20",
+            },
+        ],
+    )
+    save_discovered_listing = mocker.patch(
+        "app.sources.bat.discovery.save_discovered_listing",
+        return_value=True,
+    )
+    raw_html_writer = mocker.patch("app.sources.bat.ingest.save_listing_html")
+
+    summary = discovery.discover_completed_auctions(
+        results_url="https://bringatrailer.com/auctions/results/",
+        scrape_date=date(2026, 4, 20),
+    )
+
+    assert summary == discovery.DiscoverySummary(
+        candidates_inspected=2,
+        newly_discovered=1,
+        already_discovered_or_updated=0,
+        failed=1,
+    )
+    save_discovered_listing.assert_called_once_with(
+        {
+            "listing_id": "in-scope",
+            "url": "https://bringatrailer.com/listing/in-scope/",
+            "auction_end_date": "2026-04-20",
+        }
+    )
+    raw_html_writer.assert_not_called()
+
+
 def test_build_discovered_listing_params_maps_candidate_to_schema_columns():
     params = discovery.build_discovered_listing_params(_candidate())
 
@@ -217,6 +382,9 @@ def test_save_discovered_listing_executes_upsert_for_visible_metadata(mocker, ca
 
         def execute(self, sql, params):
             calls["executions"].append((sql, params))
+
+        def fetchone(self):
+            return (True,)
 
     class FakeConnection:
         def __enter__(self):


### PR DESCRIPTION
## Summary

- add a `discover` BAT CLI command with `--results-url`, `--scrape-date`, and `--max-candidates`
- fetch the BAT results page, parse completed-auction candidates, apply scrape-date stop gating, and upsert into `discovered_listings`
- add focused unit coverage for discovery dispatch, summary reporting, results fetching, stop gating, and failure handling

## Notes

- discovery remains independent from raw HTML persistence, transform, and load
- no Show More support was added in this first implementation
- candidates missing `auction_end_date` are treated as failed and skipped rather than using a fallback gate

## Verification

```powershell
.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_cli.py tests\unit\bat\test_discovery.py
```

Result: `28 passed in 0.38s`.

Closes #60