### PR TITLE
[codex] Refactor BAT discovery to use JSON endpoint

### DIFF
--- a/app/sources/bat/cli.py
+++ b/app/sources/bat/cli.py
@@ -24,10 +24,6 @@ def build_parser():
 
     discover_parser = subparsers.add_parser("discover")
     discover_parser.add_argument(
-        "--results-url",
-        default="https://bringatrailer.com/auctions/results/",
-    )
-    discover_parser.add_argument(
         "--scrape-date",
         type=date.fromisoformat,
         default=date.today(),
@@ -64,9 +60,8 @@ def run_listing(listing_id):
     load_listing(transformed_listing)
 
 
-def discover_listings(results_url, scrape_date, max_candidates=None):
+def discover_listings(scrape_date, max_candidates=None):
     return discover_completed_auctions(
-        results_url=results_url,
         scrape_date=scrape_date,
         max_candidates=max_candidates,
     )
@@ -79,13 +74,11 @@ def main(argv=None):
     try:
         if args.command == "discover":
             logger.info(
-                "BAT discover command started for results_url=%s scrape_date=%s max_candidates=%s",
-                args.results_url,
+                "BAT discover command started for scrape_date=%s max_candidates=%s",
                 args.scrape_date.isoformat(),
                 args.max_candidates,
             )
             summary = discover_listings(
-                results_url=args.results_url,
                 scrape_date=args.scrape_date,
                 max_candidates=args.max_candidates,
             )
@@ -104,8 +97,7 @@ def main(argv=None):
                 f"failed={summary.failed}"
             )
             logger.info(
-                "BAT discover command completed for results_url=%s scrape_date=%s",
-                args.results_url,
+                "BAT discover command completed for scrape_date=%s",
                 args.scrape_date.isoformat(),
             )
             return
@@ -122,8 +114,7 @@ def main(argv=None):
     except Exception:
         if args.command == "discover":
             logger.error(
-                "BAT discover command failed for results_url=%s scrape_date=%s",
-                args.results_url,
+                "BAT discover command failed for scrape_date=%s",
                 args.scrape_date.isoformat(),
             )
         else:

--- a/app/sources/bat/discovery.py
+++ b/app/sources/bat/discovery.py
@@ -2,17 +2,18 @@ import logging
 import os
 import re
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from urllib.parse import urljoin, urlparse
 
-from bs4 import BeautifulSoup
 import psycopg
 import requests
 
 
 SOURCE_SITE = "bringatrailer"
 BASE_URL = "https://bringatrailer.com"
-COMPLETED_AUCTIONS_SECTION_TITLE = "All Completed Auctions"
+LISTINGS_FILTER_URL = f"{BASE_URL}/wp-json/bringatrailer/1.0/data/listings-filter"
+DISCOVERY_PER_PAGE = 60
+DISCOVERY_TIMEOUT_SECONDS = 10
 logger = logging.getLogger(__name__)
 
 
@@ -50,90 +51,127 @@ class DiscoverySummary:
     failed: int = 0
 
 
-def parse_completed_auction_candidates(html, max_candidates=None):
-    if max_candidates is not None and max_candidates <= 0:
-        return []
+def fetch_completed_auctions_page(page):
+    if page <= 0:
+        raise ValueError("page must be positive")
+    if not 10 <= DISCOVERY_PER_PAGE <= 60:
+        raise ValueError("DISCOVERY_PER_PAGE must be between 10 and 60")
 
-    soup = BeautifulSoup(html, "html.parser")
-    heading = _find_completed_auctions_heading(soup)
-    if heading is None:
-        return []
-
-    candidates = []
-    seen_listing_ids = set()
-
-    for link in _iter_completed_auction_links(heading):
-        normalized = _normalize_listing_href(link.get("href"))
-        if normalized is None:
-            continue
-
-        listing_id, url = normalized
-        if listing_id in seen_listing_ids:
-            continue
-
-        seen_listing_ids.add(listing_id)
-        candidate = {
-            "source_site": SOURCE_SITE,
-            "listing_id": listing_id,
-            "source_listing_id": listing_id,
-            "url": url,
-        }
-        candidate.update(_extract_card_metadata(link))
-        candidates.append(candidate)
-
-        if max_candidates is not None and len(candidates) >= max_candidates:
-            break
-
-    return candidates
-
-
-def fetch_completed_auctions_results(results_url):
-    logger.info("Fetching BAT completed auctions results from url=%s", results_url)
-    response = requests.get(results_url, timeout=10)
+    params = {
+        "page": page,
+        "per_page": DISCOVERY_PER_PAGE,
+        "get_items": 1,
+        "get_stats": 0,
+        "sort": "td",
+    }
+    logger.info("Fetching BAT completed auctions page=%s", page)
+    response = requests.get(
+        LISTINGS_FILTER_URL,
+        params=params,
+        timeout=DISCOVERY_TIMEOUT_SECONDS,
+    )
     response.raise_for_status()
-    logger.info("Fetched BAT completed auctions results from url=%s", results_url)
-    return response.text
+    payload = response.json()
+    items = payload.get("items")
+    if items is None:
+        items = []
+    if not isinstance(items, list):
+        raise ValueError("BAT discovery payload items must be a list")
+    logger.info("Fetched BAT completed auctions page=%s items=%s", page, len(items))
+    return payload
 
 
-def discover_completed_auctions(results_url, scrape_date, max_candidates=None):
+def normalize_completed_auction_candidate(item):
+    normalized = _normalize_listing_url(item.get("url"))
+    if normalized is None:
+        raise ValueError("BAT discovery item url must be a Bring a Trailer listing URL")
+
+    listing_id, url = normalized
+    candidate = {
+        "source_site": SOURCE_SITE,
+        "listing_id": listing_id,
+        "source_listing_id": listing_id,
+        "url": url,
+    }
+
+    title = item.get("title")
+    if title:
+        candidate["title"] = str(title).strip()
+
+    auction_end_date = _parse_auction_end_date(item.get("timestamp_end"))
+    if auction_end_date:
+        candidate["auction_end_date"] = auction_end_date
+
+    source_location = item.get("country_code")
+    if source_location:
+        candidate["source_location"] = str(source_location).strip()
+
+    return candidate
+
+
+def discover_completed_auctions(scrape_date, max_candidates=None):
+    if max_candidates is not None and max_candidates <= 0:
+        return DiscoverySummary()
+
     normalized_scrape_date = _normalize_scrape_date(scrape_date)
-    html = fetch_completed_auctions_results(results_url)
-    candidates = parse_completed_auction_candidates(html, max_candidates=max_candidates)
     summary = DiscoverySummary()
+    page = 1
 
-    for candidate in candidates:
-        summary.candidates_inspected += 1
-        listing_id = candidate["listing_id"]
-        auction_end_date = candidate.get("auction_end_date")
-
-        if not auction_end_date:
-            summary.failed += 1
-            logger.error(
-                "Failed BAT discovery candidate for listing_id=%s because auction_end_date is missing",
-                listing_id,
-            )
-            continue
-
-        if date.fromisoformat(auction_end_date) < normalized_scrape_date:
-            logger.info(
-                "Stopping BAT discovery at listing_id=%s because auction_end_date=%s is older than scrape_date=%s",
-                listing_id,
-                auction_end_date,
-                normalized_scrape_date.isoformat(),
-            )
+    while True:
+        payload = fetch_completed_auctions_page(page)
+        items = payload.get("items") or []
+        if not items:
+            logger.info("Stopping BAT discovery at page=%s because no items were returned", page)
             break
 
-        try:
-            if save_discovered_listing(candidate):
-                summary.newly_discovered += 1
-            else:
-                summary.already_discovered_or_updated += 1
-        except Exception:
-            summary.failed += 1
-            logger.error(
-                "Failed BAT discovery candidate for listing_id=%s",
-                listing_id,
-            )
+        stop_discovery = False
+        for item in items:
+            if max_candidates is not None and summary.candidates_inspected >= max_candidates:
+                stop_discovery = True
+                break
+
+            candidate = _build_candidate_from_item(item, summary)
+            if candidate is None:
+                continue
+
+            summary.candidates_inspected += 1
+            listing_id = candidate["listing_id"]
+            auction_end_date = candidate.get("auction_end_date")
+
+            if not auction_end_date:
+                summary.failed += 1
+                logger.error(
+                    "Failed BAT discovery candidate for listing_id=%s because auction_end_date is missing",
+                    listing_id,
+                )
+                continue
+
+            if date.fromisoformat(auction_end_date) < normalized_scrape_date:
+                logger.info(
+                    "Stopping BAT discovery at listing_id=%s because auction_end_date=%s is older than scrape_date=%s",
+                    listing_id,
+                    auction_end_date,
+                    normalized_scrape_date.isoformat(),
+                )
+                stop_discovery = True
+                break
+
+            try:
+                if save_discovered_listing(candidate):
+                    summary.newly_discovered += 1
+                else:
+                    summary.already_discovered_or_updated += 1
+            except Exception:
+                summary.failed += 1
+                logger.error(
+                    "Failed BAT discovery candidate for listing_id=%s",
+                    listing_id,
+                )
+
+        if stop_discovery:
+            break
+
+        page += 1
 
     return summary
 
@@ -177,36 +215,23 @@ def _normalize_scrape_date(value):
     raise TypeError("scrape_date must be a date or ISO date string")
 
 
-def _find_completed_auctions_heading(soup):
-    for tag in soup.find_all(True):
-        if _normalized_text(tag) == COMPLETED_AUCTIONS_SECTION_TITLE:
-            return tag
-    return None
-
-
-def _iter_completed_auction_links(heading):
-    for element in heading.next_elements:
-        if element is heading:
-            continue
-        if not getattr(element, "name", None):
-            continue
-        if (
-            element.name == "a"
-            and element.get("href")
-            and _is_listing_card_link(element)
-        ):
-            yield element
-
-
-def _is_listing_card_link(element):
-    return "listing-card" in element.get("class", [])
-
-
-def _normalize_listing_href(href):
-    if not href:
+def _build_candidate_from_item(item, summary):
+    try:
+        return normalize_completed_auction_candidate(item)
+    except Exception:
+        summary.failed += 1
+        logger.error(
+            "Failed BAT discovery item normalization for url=%s",
+            item.get("url"),
+        )
         return None
 
-    parsed = urlparse(urljoin(BASE_URL, href))
+
+def _normalize_listing_url(url):
+    if not url:
+        return None
+
+    parsed = urlparse(urljoin(BASE_URL, url))
     if parsed.netloc and parsed.netloc.lower() != "bringatrailer.com":
         return None
 
@@ -218,60 +243,9 @@ def _normalize_listing_href(href):
     return listing_id, f"{BASE_URL}/listing/{listing_id}/"
 
 
-def _extract_card_metadata(card):
-    metadata = {}
-
-    title = _extract_title(card)
-    if title:
-        metadata["title"] = title
-
-    auction_end_date = _extract_auction_end_date(card)
-    if auction_end_date:
-        metadata["auction_end_date"] = auction_end_date
-
-    source_location = _extract_source_location(card)
-    if source_location:
-        metadata["source_location"] = source_location
-
-    return metadata
-
-
-def _extract_title(card):
-    title = card.select_one(".content-main h3")
-    if title is None:
-        return None
-    return _normalized_text(title) or None
-
-
-def _extract_auction_end_date(card):
-    result = card.select_one(".content-main .item-results")
-    if result is None:
-        return None
-    return _parse_date(_normalized_text(result))
-
-
-def _extract_source_location(card):
-    location = card.select_one(".content-main .show-country-name")
-    if location is None:
-        return None
-    return _normalized_text(location) or None
-
-
-def _parse_date(value):
-    if not value:
+def _parse_auction_end_date(timestamp_end):
+    if timestamp_end in (None, ""):
         return None
 
-    text = str(value).strip()
-    iso_match = re.search(r"\d{4}-\d{2}-\d{2}", text)
-    if iso_match:
-        return iso_match.group(0)
-
-    numeric_match = re.search(r"\d{1,2}/\d{1,2}/\d{4}", text)
-    if numeric_match is None:
-        return None
-
-    return datetime.strptime(numeric_match.group(0), "%m/%d/%Y").date().isoformat()
-
-
-def _normalized_text(tag):
-    return " ".join(tag.get_text(" ", strip=True).split())
+    timestamp = int(timestamp_end)
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).date().isoformat()

--- a/tests/unit/bat/test_cli.py
+++ b/tests/unit/bat/test_cli.py
@@ -101,7 +101,6 @@ def test_discover_command_parses_without_listing_id():
     args = cli.build_parser().parse_args(["discover"])
 
     assert args.command == "discover"
-    assert args.results_url == "https://bringatrailer.com/auctions/results/"
     assert args.max_candidates is None
     assert isinstance(args.scrape_date, date)
 
@@ -121,8 +120,6 @@ def test_discover_command_dispatches_with_parsed_options(mocker, caplog, capsys)
     cli.main(
         [
             "discover",
-            "--results-url",
-            "https://bringatrailer.com/auctions/results/page/2/",
             "--scrape-date",
             "2026-04-20",
             "--max-candidates",
@@ -131,19 +128,14 @@ def test_discover_command_dispatches_with_parsed_options(mocker, caplog, capsys)
     )
 
     discover_completed_auctions.assert_called_once_with(
-        results_url="https://bringatrailer.com/auctions/results/page/2/",
         scrape_date=date(2026, 4, 20),
         max_candidates=5,
     )
     assert (
-        "BAT discover command started for results_url=https://bringatrailer.com/auctions/results/page/2/ "
-        "scrape_date=2026-04-20 max_candidates=5"
+        "BAT discover command started for scrape_date=2026-04-20 max_candidates=5"
     ) in caplog.text
     assert "BAT discover summary inspected=2 new=1 existing_or_updated=1 failed=0" in caplog.text
-    assert (
-        "BAT discover command completed for results_url=https://bringatrailer.com/auctions/results/page/2/ "
-        "scrape_date=2026-04-20"
-    ) in caplog.text
+    assert "BAT discover command completed for scrape_date=2026-04-20" in caplog.text
     assert (
         "Discovery summary: inspected=2 new=1 existing_or_updated=1 failed=0"
         in capsys.readouterr().out
@@ -162,16 +154,18 @@ def test_discover_command_logs_failure_context_without_traceback_and_reraises(mo
         cli.main(["discover", "--scrape-date", "2026-04-20"])
 
     assert exc_info.value is error
-    assert (
-        "BAT discover command started for results_url=https://bringatrailer.com/auctions/results/ "
-        "scrape_date=2026-04-20 max_candidates=None"
-    ) in caplog.text
-    assert (
-        "BAT discover command failed for results_url=https://bringatrailer.com/auctions/results/ "
-        "scrape_date=2026-04-20"
-    ) in caplog.text
+    assert "BAT discover command started for scrape_date=2026-04-20 max_candidates=None" in caplog.text
+    assert "BAT discover command failed for scrape_date=2026-04-20" in caplog.text
     assert "Traceback" not in caplog.text
     assert "RuntimeError: discover failed" not in caplog.text
+
+
+def test_discover_command_rejects_results_url_option(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["discover", "--results-url", "https://bringatrailer.com/auctions/results/"])
+
+    assert exc_info.value.code == 2
+    assert "--results-url" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize("command", ["ingest", "transform", "load", "run"])

--- a/tests/unit/bat/test_discovery.py
+++ b/tests/unit/bat/test_discovery.py
@@ -1,224 +1,84 @@
 import logging
-from datetime import date
-from pathlib import Path
+from datetime import date, datetime, timezone
 
 import pytest
 
 from app.sources.bat import discovery
 
-FIXTURES_DIR = Path(__file__).parents[2] / "fixtures"
 
-
-def test_parse_completed_auction_candidates_returns_normalized_unique_candidates():
-    candidates = discovery.parse_completed_auction_candidates(_results_html())
-
-    assert candidates == [
-        {
-            "source_site": "bringatrailer",
-            "listing_id": "newest-car",
-            "source_listing_id": "newest-car",
-            "url": "https://bringatrailer.com/listing/newest-car/",
-            "title": "1995 Porsche 911 Carrera Coupe",
-            "auction_end_date": "2026-04-19",
-            "source_location": "USA",
-        },
-        {
-            "source_site": "bringatrailer",
-            "listing_id": "older-car",
-            "source_listing_id": "older-car",
-            "url": "https://bringatrailer.com/listing/older-car/",
-            "title": "2004 BMW M3 Coupe",
-            "auction_end_date": "2026-04-18",
-            "source_location": "CAN",
-        },
-    ]
-
-
-def test_parse_completed_auction_candidates_starts_at_completed_auctions_section():
-    candidates = discovery.parse_completed_auction_candidates(
-        """
-        <main>
-            <h2>This Week's Popular Listings</h2>
-            <article>
-                <a href="/listing/popular-listing/">Popular listing</a>
-            </article>
-            <h2>Selected Market Results</h2>
-            <article>
-                <a href="/listing/market-result/">Market result</a>
-            </article>
-            <h2>Recent Exceptional Results</h2>
-            <a class="listing-card" href="/listing/exceptional-result/">
-                <h3>Exceptional result</h3>
-            </a>
-            <h2>All Completed Auctions</h2>
-            <a class="listing-card" href="/listing/target-listing/">
-                <h3>Target listing</h3>
-            </a>
-        </main>
-        """
-    )
-
-    assert [candidate["listing_id"] for candidate in candidates] == ["target-listing"]
-
-
-def test_parse_completed_auction_candidates_ignores_non_listing_links():
-    candidates = discovery.parse_completed_auction_candidates(
-        """
-        <main>
-            <h2>All Completed Auctions</h2>
-            <nav>
-                <a href="/">Home</a>
-                <a href="/auctions/">Auctions</a>
-                <a href="/search/?q=porsche">Search</a>
-                <a href="/parts/air-cooled-sign/">Parts</a>
-                <a href="/model/porsche-911/">Model market</a>
-                <a href="https://example.com/listing/not-bat/">External</a>
-                <a href="/listing/not-a-card/">Not a card</a>
-            </nav>
-            <a class="listing-card" href="/listing/real-listing/">
-                <h3>Real listing</h3>
-            </a>
-        </main>
-        """
-    )
-
-    assert [candidate["listing_id"] for candidate in candidates] == ["real-listing"]
-
-
-def test_parse_completed_auction_candidates_applies_max_after_normalization():
-    candidates = discovery.parse_completed_auction_candidates(
-        _results_html(), max_candidates=1
-    )
-
-    assert [candidate["listing_id"] for candidate in candidates] == ["newest-car"]
-
-
-def test_parse_completed_auction_candidates_allows_missing_metadata():
-    candidates = discovery.parse_completed_auction_candidates(
-        """
-        <main>
-            <h2>All Completed Auctions</h2>
-            <a class="listing-card" href="/listing/no-metadata/">View listing</a>
-        </main>
-        """
-    )
-
-    assert candidates == [
-        {
-            "source_site": "bringatrailer",
-            "listing_id": "no-metadata",
-            "source_listing_id": "no-metadata",
-            "url": "https://bringatrailer.com/listing/no-metadata/",
-        }
-    ]
-
-
-def test_parse_completed_auction_candidates_returns_empty_without_target_section():
-    candidates = discovery.parse_completed_auction_candidates(
-        """
-        <main>
-            <h2>This Week's Popular Listings</h2>
-            <article>
-                <a href="/listing/popular-listing/">Popular listing</a>
-            </article>
-        </main>
-        """
-    )
-
-    assert candidates == []
-
-
-def test_parse_completed_auction_candidates_ignores_json_initial_data_only():
-    candidates = discovery.parse_completed_auction_candidates(
-        """
-        <main>
-            <h2>All Completed Auctions</h2>
-            <script id="bat-theme-auctions-completed-initial-data">
-                var auctionsCompletedInitialData = {
-                    "items": [
-                        {
-                            "title": "JSON-only listing",
-                            "url": "https://bringatrailer.com/listing/json-only/"
-                        }
-                    ]
-                };
-            </script>
-        </main>
-        """
-    )
-
-    assert candidates == []
-
-
-def test_parse_completed_auction_candidates_reads_rendered_card_fixture():
-    card = (FIXTURES_DIR / "card.html").read_text(encoding="utf-8")
-
-    candidates = discovery.parse_completed_auction_candidates(
-        f"""
-        <main>
-            <h2>All Completed Auctions</h2>
-            {card}
-        </main>
-        """
-    )
-
-    assert candidates == [
-        {
-            "source_site": "bringatrailer",
-            "listing_id": "1958-gmc-pickup-7",
-            "source_listing_id": "1958-gmc-pickup-7",
-            "url": "https://bringatrailer.com/listing/1958-gmc-pickup-7/",
-            "title": "1958 GMC 9310 Stepside Pickup 3-Speed",
-            "auction_end_date": "2026-04-20",
-            "source_location": "CAN",
-        }
-    ]
-
-
-def test_fetch_completed_auctions_results_uses_url_and_timeout(mocker, caplog):
+def test_fetch_completed_auctions_page_uses_endpoint_params_and_timeout(mocker, caplog):
     response = mocker.Mock()
-    response.text = "<html>Results</html>"
+    response.json.return_value = {"items": [{"url": "https://bringatrailer.com/listing/test/"}]}
     response.raise_for_status = mocker.Mock()
     mock_get = mocker.patch("app.sources.bat.discovery.requests.get", return_value=response)
 
     caplog.set_level(logging.INFO)
-    html = discovery.fetch_completed_auctions_results(
-        "https://bringatrailer.com/auctions/results/"
-    )
+    payload = discovery.fetch_completed_auctions_page(2)
 
-    assert html == "<html>Results</html>"
+    assert payload == {"items": [{"url": "https://bringatrailer.com/listing/test/"}]}
     mock_get.assert_called_once_with(
-        "https://bringatrailer.com/auctions/results/",
+        discovery.LISTINGS_FILTER_URL,
+        params={
+            "page": 2,
+            "per_page": 60,
+            "get_items": 1,
+            "get_stats": 0,
+            "sort": "td",
+        },
         timeout=10,
     )
     response.raise_for_status.assert_called_once_with()
-    assert "Fetching BAT completed auctions results from url=https://bringatrailer.com/auctions/results/" in caplog.text
-    assert "Fetched BAT completed auctions results from url=https://bringatrailer.com/auctions/results/" in caplog.text
+    response.json.assert_called_once_with()
+    assert "Fetching BAT completed auctions page=2" in caplog.text
+    assert "Fetched BAT completed auctions page=2 items=1" in caplog.text
 
 
-def test_discover_completed_auctions_returns_summary_counts(mocker):
-    mocker.patch(
-        "app.sources.bat.discovery.fetch_completed_auctions_results",
-        return_value="<html>Results</html>",
+def test_normalize_completed_auction_candidate_maps_endpoint_item():
+    candidate = discovery.normalize_completed_auction_candidate(
+        {
+            "url": "https://bringatrailer.com/listing/test-listing/?utm_source=feed#comments",
+            "title": " 2004 BMW M3 Coupe ",
+            "timestamp_end": _timestamp("2026-04-20"),
+            "country_code": "USA",
+        }
     )
-    mocker.patch(
-        "app.sources.bat.discovery.parse_completed_auction_candidates",
-        return_value=[
+
+    assert candidate == {
+        "source_site": "bringatrailer",
+        "listing_id": "test-listing",
+        "source_listing_id": "test-listing",
+        "url": "https://bringatrailer.com/listing/test-listing/",
+        "title": "2004 BMW M3 Coupe",
+        "auction_end_date": "2026-04-20",
+        "source_location": "USA",
+    }
+
+
+def test_normalize_completed_auction_candidate_allows_missing_optional_metadata():
+    candidate = discovery.normalize_completed_auction_candidate(
+        {"url": "/listing/test-listing/"}
+    )
+
+    assert candidate == {
+        "source_site": "bringatrailer",
+        "listing_id": "test-listing",
+        "source_listing_id": "test-listing",
+        "url": "https://bringatrailer.com/listing/test-listing/",
+    }
+
+
+def test_discover_completed_auctions_returns_summary_counts_across_pages(mocker):
+    fetch_completed_auctions_page = mocker.patch(
+        "app.sources.bat.discovery.fetch_completed_auctions_page",
+        side_effect=[
             {
-                "listing_id": "new-car",
-                "url": "https://bringatrailer.com/listing/new-car/",
-                "auction_end_date": "2026-04-20",
+                "items": [
+                    _item("new-car", "2026-04-20", "New Car"),
+                    _item("existing-car", "2026-04-20", "Existing Car"),
+                ]
             },
-            {
-                "listing_id": "existing-car",
-                "url": "https://bringatrailer.com/listing/existing-car/",
-                "auction_end_date": "2026-04-20",
-            },
-            {
-                "listing_id": "broken-car",
-                "url": "https://bringatrailer.com/listing/broken-car/",
-                "auction_end_date": "2026-04-20",
-            },
+            {"items": [_item("broken-car", "2026-04-20", "Broken Car")]},
+            {"items": []},
         ],
     )
     save_discovered_listing = mocker.patch(
@@ -227,9 +87,7 @@ def test_discover_completed_auctions_returns_summary_counts(mocker):
     )
 
     summary = discovery.discover_completed_auctions(
-        results_url="https://bringatrailer.com/auctions/results/",
         scrape_date=date(2026, 4, 20),
-        max_candidates=3,
     )
 
     assert summary == discovery.DiscoverySummary(
@@ -238,37 +96,22 @@ def test_discover_completed_auctions_returns_summary_counts(mocker):
         already_discovered_or_updated=1,
         failed=1,
     )
+    assert [call.args[0] for call in fetch_completed_auctions_page.call_args_list] == [1, 2, 3]
     assert save_discovered_listing.call_count == 3
 
 
 def test_discover_completed_auctions_stops_when_candidate_is_older_than_scrape_date(mocker):
-    mocker.patch(
-        "app.sources.bat.discovery.fetch_completed_auctions_results",
-        return_value="<html>Results</html>",
-    )
-    mocker.patch(
-        "app.sources.bat.discovery.parse_completed_auction_candidates",
-        return_value=[
+    fetch_completed_auctions_page = mocker.patch(
+        "app.sources.bat.discovery.fetch_completed_auctions_page",
+        side_effect=[
             {
-                "listing_id": "newest-car",
-                "url": "https://bringatrailer.com/listing/newest-car/",
-                "auction_end_date": "2026-04-20",
+                "items": [
+                    _item("newest-car", "2026-04-20"),
+                    _item("same-day-car", "2026-04-20"),
+                    _item("older-car", "2026-04-19"),
+                ]
             },
-            {
-                "listing_id": "same-day-car",
-                "url": "https://bringatrailer.com/listing/same-day-car/",
-                "auction_end_date": "2026-04-20",
-            },
-            {
-                "listing_id": "older-car",
-                "url": "https://bringatrailer.com/listing/older-car/",
-                "auction_end_date": "2026-04-19",
-            },
-            {
-                "listing_id": "oldest-car",
-                "url": "https://bringatrailer.com/listing/oldest-car/",
-                "auction_end_date": "2026-04-18",
-            },
+            {"items": [_item("should-not-fetch", "2026-04-19")]},
         ],
     )
     save_discovered_listing = mocker.patch(
@@ -277,7 +120,6 @@ def test_discover_completed_auctions_stops_when_candidate_is_older_than_scrape_d
     )
 
     summary = discovery.discover_completed_auctions(
-        results_url="https://bringatrailer.com/auctions/results/",
         scrape_date="2026-04-20",
     )
 
@@ -291,35 +133,24 @@ def test_discover_completed_auctions_stops_when_candidate_is_older_than_scrape_d
         "newest-car",
         "same-day-car",
     ]
+    assert [call.args[0] for call in fetch_completed_auctions_page.call_args_list] == [1]
 
 
 def test_discover_completed_auctions_marks_missing_auction_end_date_as_failed(mocker):
     mocker.patch(
-        "app.sources.bat.discovery.fetch_completed_auctions_results",
-        return_value="<html>Results</html>",
-    )
-    mocker.patch(
-        "app.sources.bat.discovery.parse_completed_auction_candidates",
-        return_value=[
-            {
-                "listing_id": "missing-date",
-                "url": "https://bringatrailer.com/listing/missing-date/",
-            },
-            {
-                "listing_id": "in-scope",
-                "url": "https://bringatrailer.com/listing/in-scope/",
-                "auction_end_date": "2026-04-20",
-            },
+        "app.sources.bat.discovery.fetch_completed_auctions_page",
+        side_effect=[
+            {"items": [{"url": "https://bringatrailer.com/listing/missing-date/"}]},
+            {"items": [_item("in-scope", "2026-04-20")]},
+            {"items": []},
         ],
     )
     save_discovered_listing = mocker.patch(
         "app.sources.bat.discovery.save_discovered_listing",
         return_value=True,
     )
-    raw_html_writer = mocker.patch("app.sources.bat.ingest.save_listing_html")
 
     summary = discovery.discover_completed_auctions(
-        results_url="https://bringatrailer.com/auctions/results/",
         scrape_date=date(2026, 4, 20),
     )
 
@@ -331,12 +162,108 @@ def test_discover_completed_auctions_marks_missing_auction_end_date_as_failed(mo
     )
     save_discovered_listing.assert_called_once_with(
         {
+            "source_site": "bringatrailer",
             "listing_id": "in-scope",
+            "source_listing_id": "in-scope",
             "url": "https://bringatrailer.com/listing/in-scope/",
+            "title": "In Scope",
             "auction_end_date": "2026-04-20",
+            "source_location": "USA",
         }
     )
-    raw_html_writer.assert_not_called()
+
+
+def test_discover_completed_auctions_stops_at_max_candidates_without_extra_page_fetch(mocker):
+    fetch_completed_auctions_page = mocker.patch(
+        "app.sources.bat.discovery.fetch_completed_auctions_page",
+        side_effect=[
+            {
+                "items": [
+                    _item("first-car", "2026-04-20"),
+                    _item("second-car", "2026-04-20"),
+                    _item("third-car", "2026-04-20"),
+                ]
+            },
+            {"items": [_item("should-not-fetch", "2026-04-20")]},
+        ],
+    )
+    save_discovered_listing = mocker.patch(
+        "app.sources.bat.discovery.save_discovered_listing",
+        return_value=True,
+    )
+
+    summary = discovery.discover_completed_auctions(
+        scrape_date="2026-04-20",
+        max_candidates=2,
+    )
+
+    assert summary == discovery.DiscoverySummary(
+        candidates_inspected=2,
+        newly_discovered=2,
+        already_discovered_or_updated=0,
+        failed=0,
+    )
+    assert [call.args[0]["listing_id"] for call in save_discovered_listing.call_args_list] == [
+        "first-car",
+        "second-car",
+    ]
+    assert [call.args[0] for call in fetch_completed_auctions_page.call_args_list] == [1]
+
+
+def test_discover_completed_auctions_stops_when_endpoint_returns_no_items(mocker):
+    fetch_completed_auctions_page = mocker.patch(
+        "app.sources.bat.discovery.fetch_completed_auctions_page",
+        side_effect=[
+            {"items": [_item("first-car", "2026-04-20")]},
+            {"items": []},
+        ],
+    )
+    save_discovered_listing = mocker.patch(
+        "app.sources.bat.discovery.save_discovered_listing",
+        return_value=True,
+    )
+
+    summary = discovery.discover_completed_auctions(
+        scrape_date="2026-04-20",
+    )
+
+    assert summary == discovery.DiscoverySummary(
+        candidates_inspected=1,
+        newly_discovered=1,
+        already_discovered_or_updated=0,
+        failed=0,
+    )
+    assert [call.args[0] for call in fetch_completed_auctions_page.call_args_list] == [1, 2]
+    save_discovered_listing.assert_called_once()
+
+
+def test_discover_completed_auctions_counts_normalization_failures_and_continues(mocker):
+    mocker.patch(
+        "app.sources.bat.discovery.fetch_completed_auctions_page",
+        side_effect=[
+            {
+                "items": [
+                    {"url": "https://example.com/not-bat/"},
+                    _item("valid-car", "2026-04-20"),
+                ]
+            },
+            {"items": []},
+        ],
+    )
+    save_discovered_listing = mocker.patch(
+        "app.sources.bat.discovery.save_discovered_listing",
+        return_value=True,
+    )
+
+    summary = discovery.discover_completed_auctions(scrape_date="2026-04-20")
+
+    assert summary == discovery.DiscoverySummary(
+        candidates_inspected=1,
+        newly_discovered=1,
+        already_discovered_or_updated=0,
+        failed=1,
+    )
+    save_discovered_listing.assert_called_once()
 
 
 def test_build_discovered_listing_params_maps_candidate_to_schema_columns():
@@ -452,34 +379,19 @@ def _candidate():
     }
 
 
-def _results_html():
-    return """
-    <main>
-        <section>
-            <h2>All Completed Auctions</h2>
-            <a class="listing-card" href="/listing/newest-car/?utm_source=feed">
-                <div class="content-main">
-                    <h3>1995 Porsche 911 Carrera Coupe</h3>
-                    <span class="show-country-name">USA</span>
-                    <div class="item-results">
-                        Sold for USD $19,911 <span> on 04/19/2026 </span>
-                    </div>
-                </div>
-            </a>
-            <a class="listing-card" href="https://bringatrailer.com/listing/newest-car#comments">
-                <div class="content-main">
-                    <h3>Duplicate link</h3>
-                </div>
-            </a>
-            <a class="listing-card" href="https://bringatrailer.com/listing/older-car/">
-                <div class="content-main">
-                    <h3>2004 BMW M3 Coupe</h3>
-                    <span class="show-country-name">CAN</span>
-                    <div class="item-results">
-                        Bid to USD $30,000 <span> on 04/18/2026 </span>
-                    </div>
-                </div>
-            </a>
-        </section>
-    </main>
-    """
+def _item(listing_id, auction_end_date, title=None, country_code="USA"):
+    return {
+        "url": f"https://bringatrailer.com/listing/{listing_id}/",
+        "title": title or listing_id.replace("-", " ").title(),
+        "timestamp_end": _timestamp(auction_end_date),
+        "country_code": country_code,
+        "pages_total": 999,
+    }
+
+
+def _timestamp(iso_date):
+    return int(
+        datetime.fromisoformat(f"{iso_date}T12:00:00+00:00")
+        .astimezone(timezone.utc)
+        .timestamp()
+    )


### PR DESCRIPTION
## Summary

- replace BAT discovery HTML scraping with paginated requests to the listings JSON endpoint
- normalize endpoint items into the existing discovered-listing contract and stop on scrape-date, max-candidates, or empty items
- remove `--results-url` from the `discover` CLI and update focused unit coverage for the new endpoint-backed flow

## Verification

```powershell
.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_cli.py tests\unit\bat\test_discovery.py
```

Result: `26 passed in 0.35s`.

Closes #64