### PR TITLE
Add discovered-listing batch selection and eligibility update helpers

### DIFF
--- a/app/sources/bat/discovery.py
+++ b/app/sources/bat/discovery.py
@@ -7,6 +7,7 @@ from urllib.parse import urljoin, urlparse
 
 import psycopg
 import requests
+from psycopg.rows import dict_row
 
 
 SOURCE_SITE = "bringatrailer"
@@ -40,6 +41,44 @@ ON CONFLICT (source_site, source_listing_id) DO UPDATE SET
     source_location = EXCLUDED.source_location,
     last_seen_at = NOW()
 RETURNING xmax = 0 AS inserted
+"""
+
+SELECT_PENDING_DISCOVERED_LISTINGS_SQL = """
+SELECT
+    id,
+    source_site,
+    source_listing_id,
+    url,
+    title,
+    auction_end_date,
+    source_location,
+    eligible,
+    eligibility_reason,
+    discovered_at,
+    last_seen_at,
+    ingested_at
+FROM discovered_listings
+WHERE source_site = %(source_site)s
+  AND ingested_at IS NULL
+ORDER BY discovered_at ASC, id ASC
+"""
+
+MARK_DISCOVERED_LISTING_HANDLED_INELIGIBLE_SQL = """
+UPDATE discovered_listings
+SET ingested_at = NOW(),
+    eligible = FALSE,
+    eligibility_reason = %(eligibility_reason)s
+WHERE source_site = %(source_site)s
+  AND source_listing_id = %(source_listing_id)s
+"""
+
+MARK_DISCOVERED_LISTING_HANDLED_ELIGIBLE_SQL = """
+UPDATE discovered_listings
+SET ingested_at = NOW(),
+    eligible = TRUE,
+    eligibility_reason = NULL
+WHERE source_site = %(source_site)s
+  AND source_listing_id = %(source_listing_id)s
 """
 
 
@@ -177,9 +216,7 @@ def discover_completed_auctions(scrape_date, max_candidates=None):
 
 
 def save_discovered_listing(candidate):
-    database_url = os.environ.get("DATABASE_URL")
-    if not database_url:
-        raise RuntimeError("DATABASE_URL must be set")
+    database_url = _get_database_url()
 
     params = build_discovered_listing_params(candidate)
 
@@ -194,6 +231,48 @@ def save_discovered_listing(candidate):
             return inserted
 
 
+def load_pending_discovered_listings(limit=None):
+    database_url = _get_database_url()
+    params = {"source_site": SOURCE_SITE}
+    sql = SELECT_PENDING_DISCOVERED_LISTINGS_SQL
+
+    if limit is not None:
+        if limit <= 0:
+            return []
+        sql = f"{sql}\nLIMIT %(limit)s"
+        params["limit"] = limit
+
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(sql, params)
+            return cur.fetchall()
+
+
+def mark_discovered_listing_handled_ineligible(listing_id, reason):
+    database_url = _get_database_url()
+    params = {
+        "source_site": SOURCE_SITE,
+        "source_listing_id": listing_id,
+        "eligibility_reason": reason,
+    }
+
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(MARK_DISCOVERED_LISTING_HANDLED_INELIGIBLE_SQL, params)
+
+
+def mark_discovered_listing_handled_eligible(listing_id):
+    database_url = _get_database_url()
+    params = {
+        "source_site": SOURCE_SITE,
+        "source_listing_id": listing_id,
+    }
+
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(MARK_DISCOVERED_LISTING_HANDLED_ELIGIBLE_SQL, params)
+
+
 def build_discovered_listing_params(candidate):
     return {
         "source_site": SOURCE_SITE,
@@ -203,6 +282,13 @@ def build_discovered_listing_params(candidate):
         "auction_end_date": candidate.get("auction_end_date"),
         "source_location": candidate.get("source_location"),
     }
+
+
+def _get_database_url():
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set")
+    return database_url
 
 
 def _normalize_scrape_date(value):

--- a/tests/integration/bat/test_load_integration.py
+++ b/tests/integration/bat/test_load_integration.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import psycopg
 import pytest
 
+from app.sources.bat import discovery
 from app.sources.bat.load import load_listing
 
 """
@@ -130,6 +131,80 @@ def test_load_listing_upserts_into_postgres_container(monkeypatch):
         subprocess.run(["docker", "rm", "-f", container_name], capture_output=True, text=True)
 
 
+def test_discovery_helpers_select_pending_rows_and_persist_handled_state(monkeypatch):
+    if not _docker_daemon_available():
+        pytest.skip("Docker daemon is not available")
+
+    container_name = f"auction-discovery-test-{uuid.uuid4().hex}"
+    schema_mount = f"{SCHEMA_PATH}:/docker-entrypoint-initdb.d/001-schema.sql:ro"
+
+    try:
+        _run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "-d",
+                "--name",
+                container_name,
+                "-e",
+                "POSTGRES_DB=auction_etl",
+                "-e",
+                "POSTGRES_USER=auction_user",
+                "-e",
+                "POSTGRES_PASSWORD=localdevpassword",
+                "-p",
+                "127.0.0.1::5432",
+                "-v",
+                schema_mount,
+                "postgres:17",
+            ]
+        )
+        _wait_for_postgres(container_name)
+
+        port = _host_port(container_name)
+        database_url = (
+            f"postgresql://auction_user:localdevpassword@127.0.0.1:{port}/auction_etl"
+        )
+        _wait_for_database_url(database_url)
+        monkeypatch.setenv("DATABASE_URL", database_url)
+        _insert_discovered_listing_rows(database_url)
+
+        pending_rows = discovery.load_pending_discovered_listings()
+        pending_ids = [row["source_listing_id"] for row in pending_rows]
+
+        limited_rows = discovery.load_pending_discovered_listings(limit=1)
+        limited_ids = [row["source_listing_id"] for row in limited_rows]
+
+        discovery.mark_discovered_listing_handled_ineligible(
+            "first-pending",
+            "sale_price missing",
+        )
+        discovery.mark_discovered_listing_handled_eligible("second-pending")
+
+        with psycopg.connect(database_url) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT source_listing_id, eligible, eligibility_reason, ingested_at IS NOT NULL
+                    FROM discovered_listings
+                    WHERE source_site = 'bringatrailer'
+                      AND source_listing_id IN ('first-pending', 'second-pending')
+                    ORDER BY source_listing_id ASC
+                    """
+                )
+                state_rows = cur.fetchall()
+
+        assert pending_ids == ["first-pending", "second-pending"]
+        assert limited_ids == ["first-pending"]
+        assert state_rows == [
+            ("first-pending", False, "sale_price missing", True),
+            ("second-pending", True, None, True),
+        ]
+    finally:
+        subprocess.run(["docker", "rm", "-f", container_name], capture_output=True, text=True)
+
+
 def _transformed_listing(sale_price, details):
     return {
         "source_site": "bringatrailer",
@@ -146,6 +221,75 @@ def _transformed_listing(sale_price, details):
         "transmission": "manual",
         "listing_details_raw": details,
     }
+
+
+def _insert_discovered_listing_rows(database_url):
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO discovered_listings (
+                    id,
+                    source_site,
+                    source_listing_id,
+                    url,
+                    title,
+                    auction_end_date,
+                    source_location,
+                    discovered_at,
+                    last_seen_at,
+                    ingested_at
+                ) VALUES
+                    (
+                        10,
+                        'bringatrailer',
+                        'first-pending',
+                        'https://bringatrailer.com/listing/first-pending/',
+                        'First Pending',
+                        DATE '2026-03-30',
+                        'USA',
+                        TIMESTAMPTZ '2026-04-20 08:00:00+00',
+                        TIMESTAMPTZ '2026-04-20 08:00:00+00',
+                        NULL
+                    ),
+                    (
+                        20,
+                        'bringatrailer',
+                        'second-pending',
+                        'https://bringatrailer.com/listing/second-pending/',
+                        'Second Pending',
+                        DATE '2026-03-31',
+                        'USA',
+                        TIMESTAMPTZ '2026-04-20 08:00:00+00',
+                        TIMESTAMPTZ '2026-04-20 08:00:00+00',
+                        NULL
+                    ),
+                    (
+                        30,
+                        'bringatrailer',
+                        'already-ingested',
+                        'https://bringatrailer.com/listing/already-ingested/',
+                        'Already Ingested',
+                        DATE '2026-03-29',
+                        'USA',
+                        TIMESTAMPTZ '2026-04-19 08:00:00+00',
+                        TIMESTAMPTZ '2026-04-19 08:00:00+00',
+                        TIMESTAMPTZ '2026-04-21 08:00:00+00'
+                    ),
+                    (
+                        40,
+                        'carsandbids',
+                        'other-source',
+                        'https://carsandbids.com/auctions/other-source',
+                        'Other Source',
+                        DATE '2026-03-28',
+                        'USA',
+                        TIMESTAMPTZ '2026-04-18 08:00:00+00',
+                        TIMESTAMPTZ '2026-04-18 08:00:00+00',
+                        NULL
+                    )
+                """
+            )
 
 
 def _docker_daemon_available():

--- a/tests/unit/bat/test_discovery.py
+++ b/tests/unit/bat/test_discovery.py
@@ -369,6 +369,206 @@ def test_save_discovered_listing_requires_database_url(mocker):
         discovery.save_discovered_listing(_candidate())
 
 
+def test_load_pending_discovered_listings_selects_pending_bat_rows_in_stable_order(mocker):
+    calls = {"executions": [], "cursor_kwargs": []}
+    expected_rows = [
+        {
+            "id": 1,
+            "source_site": "bringatrailer",
+            "source_listing_id": "first-listing",
+            "url": "https://bringatrailer.com/listing/first-listing/",
+            "title": "First Listing",
+            "auction_end_date": date(2026, 3, 30),
+            "source_location": "USA",
+            "eligible": None,
+            "eligibility_reason": None,
+            "discovered_at": datetime(2026, 4, 20, 8, 0, tzinfo=timezone.utc),
+            "last_seen_at": datetime(2026, 4, 20, 8, 0, tzinfo=timezone.utc),
+            "ingested_at": None,
+        }
+    ]
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            calls["executions"].append((sql, params))
+
+        def fetchall(self):
+            return expected_rows
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self, **kwargs):
+            calls["cursor_kwargs"].append(kwargs)
+            return FakeCursor()
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    mocker.patch.object(discovery.psycopg, "connect", return_value=FakeConnection())
+
+    rows = discovery.load_pending_discovered_listings()
+
+    sql, params = calls["executions"][0]
+    assert rows == expected_rows
+    assert calls["cursor_kwargs"] == [{"row_factory": discovery.dict_row}]
+    assert "FROM discovered_listings" in sql
+    assert "WHERE source_site = %(source_site)s" in sql
+    assert "AND ingested_at IS NULL" in sql
+    assert "ORDER BY discovered_at ASC, id ASC" in sql
+    assert "LIMIT %(limit)s" not in sql
+    assert params == {"source_site": "bringatrailer"}
+
+
+def test_load_pending_discovered_listings_applies_optional_limit(mocker):
+    calls = {"executions": []}
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            calls["executions"].append((sql, params))
+
+        def fetchall(self):
+            return []
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self, **kwargs):
+            return FakeCursor()
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    mocker.patch.object(discovery.psycopg, "connect", return_value=FakeConnection())
+
+    assert discovery.load_pending_discovered_listings(limit=2) == []
+
+    sql, params = calls["executions"][0]
+    assert "LIMIT %(limit)s" in sql
+    assert params == {"source_site": "bringatrailer", "limit": 2}
+
+
+def test_load_pending_discovered_listings_returns_empty_without_query_for_non_positive_limit(mocker):
+    connect = mocker.patch.object(discovery.psycopg, "connect")
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+
+    assert discovery.load_pending_discovered_listings(limit=0) == []
+    connect.assert_not_called()
+
+
+def test_mark_discovered_listing_handled_ineligible_updates_state(mocker):
+    calls = {"executions": []}
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            calls["executions"].append((sql, params))
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    mocker.patch.object(discovery.psycopg, "connect", return_value=FakeConnection())
+
+    discovery.mark_discovered_listing_handled_ineligible(
+        "test-listing",
+        "auction did not meet eligibility rules",
+    )
+
+    sql, params = calls["executions"][0]
+    assert "UPDATE discovered_listings" in sql
+    assert "SET ingested_at = NOW()" in sql
+    assert "eligible = FALSE" in sql
+    assert "eligibility_reason = %(eligibility_reason)s" in sql
+    assert params == {
+        "source_site": "bringatrailer",
+        "source_listing_id": "test-listing",
+        "eligibility_reason": "auction did not meet eligibility rules",
+    }
+
+
+def test_mark_discovered_listing_handled_eligible_updates_state(mocker):
+    calls = {"executions": []}
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            calls["executions"].append((sql, params))
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    mocker.patch.object(discovery.psycopg, "connect", return_value=FakeConnection())
+
+    discovery.mark_discovered_listing_handled_eligible("test-listing")
+
+    sql, params = calls["executions"][0]
+    assert "UPDATE discovered_listings" in sql
+    assert "SET ingested_at = NOW()" in sql
+    assert "eligible = TRUE" in sql
+    assert "eligibility_reason = NULL" in sql
+    assert params == {
+        "source_site": "bringatrailer",
+        "source_listing_id": "test-listing",
+    }
+
+
 def _candidate():
     return {
         "listing_id": "test-listing",


### PR DESCRIPTION
## Summary
- add helpers to load pending Bring a Trailer discovered listings in stable oldest-first order with an optional batch limit
- add helpers to mark discovered listings handled and eligible or handled and ineligible
- add focused unit and Postgres integration coverage for selection order, limit behavior, and eligibility state updates

## Verification
- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_discovery.py`
- `.venv\Scripts\python.exe -m pytest -q tests\integration\bat\test_load_integration.py` (skipped in this environment because Docker was unavailable)
