### PR TITLE
Implement BAT stage-1 and stage-2 eligibility filters

### DIFF
--- a/app/sources/bat/discovery.py
+++ b/app/sources/bat/discovery.py
@@ -17,6 +17,9 @@ DISCOVERY_PER_PAGE = 60
 DISCOVERY_TIMEOUT_SECONDS = 10
 logger = logging.getLogger(__name__)
 
+DISCOVERY_MIN_YEAR = 1946
+DISCOVERY_ALLOWED_SOURCE_LOCATION = "US"
+
 
 UPSERT_DISCOVERED_LISTING_SQL = """
 INSERT INTO discovered_listings (
@@ -284,6 +287,18 @@ def build_discovered_listing_params(candidate):
     }
 
 
+def evaluate_discovery_eligibility(title, source_location):
+    normalized_title = (title or "").strip()
+    year = _parse_title_year(normalized_title)
+    if year is None:
+        return False, "title year missing"
+    if year < DISCOVERY_MIN_YEAR:
+        return False, "year before 1946"
+    if source_location != DISCOVERY_ALLOWED_SOURCE_LOCATION:
+        return False, "listing outside US"
+    return True, None
+
+
 def _get_database_url():
     database_url = os.environ.get("DATABASE_URL")
     if not database_url:
@@ -299,6 +314,13 @@ def _normalize_scrape_date(value):
         return date.fromisoformat(value)
 
     raise TypeError("scrape_date must be a date or ISO date string")
+
+
+def _parse_title_year(title):
+    match = re.match(r"(\d{4})\b", title)
+    if not match:
+        return None
+    return int(match.group(1))
 
 
 def _build_candidate_from_item(item, summary):

--- a/app/sources/bat/transform.py
+++ b/app/sources/bat/transform.py
@@ -9,6 +9,27 @@ import psycopg
 
 SOURCE_SITE = "bringatrailer"
 logger = logging.getLogger(__name__)
+BAT_MIN_YEAR = 1946
+EXCLUDED_CATEGORY_VALUES = {
+    "aircraft",
+    "all-terrain vehicles",
+    "boats",
+    "charity & non-profit",
+    "go-karts",
+    "hot rods",
+    "military vehicles",
+    "minibikes & scooters",
+    "motorcycles",
+    "parts",
+    "projects",
+    "race cars",
+    "rvs & campers",
+    "service vehicles",
+    "side-by-sides",
+    "tractors",
+    "trains",
+    "wheels",
+}
 
 SELECT_RAW_LISTING_HTML_SQL = """
 SELECT raw_html
@@ -86,6 +107,26 @@ def transform_listing_html(listing_id):
     }
     logger.info("Transformed BAT listing HTML for listing_id=%s", listing_id)
     return transformed_data
+
+
+def evaluate_listing_eligibility(soup, listing_title):
+    try:
+        year = parse_year(listing_title)
+    except ValueError:
+        return False, "title year missing"
+
+    if year < BAT_MIN_YEAR:
+        return False, "year before 1946"
+
+    try:
+        category = extract_group_value(soup, "Category")
+    except ValueError:
+        return True, None
+
+    if _normalize_category_value(category) in EXCLUDED_CATEGORY_VALUES:
+        return False, f"excluded category: {category}"
+
+    return True, None
 
 def get_product_json_ld(soup):
     for script_tag in soup.find_all("script", attrs={"type": "application/ld+json"}):
@@ -249,3 +290,7 @@ def normalize_transmission(raw_transmission):
     if value:
         return "automatic"
     raise ValueError("Could not normalize transmission")
+
+
+def _normalize_category_value(value):
+    return " ".join(value.lower().split())

--- a/tests/unit/bat/test_discovery.py
+++ b/tests/unit/bat/test_discovery.py
@@ -67,6 +67,44 @@ def test_normalize_completed_auction_candidate_allows_missing_optional_metadata(
     }
 
 
+def test_evaluate_discovery_eligibility_accepts_in_scope_us_car_title():
+    assert discovery.evaluate_discovery_eligibility("2004 BMW M3 Coupe", "US") == (True, None)
+
+
+def test_evaluate_discovery_eligibility_rejects_missing_or_unparseable_year():
+    assert discovery.evaluate_discovery_eligibility("BMW M3 Coupe", "US") == (
+        False,
+        "title year missing",
+    )
+
+
+def test_evaluate_discovery_eligibility_rejects_pre_1946_title():
+    assert discovery.evaluate_discovery_eligibility("1941 Ford Super Deluxe Coupe", "US") == (
+        False,
+        "year before 1946",
+    )
+
+
+def test_evaluate_discovery_eligibility_rejects_non_us_listing():
+    assert discovery.evaluate_discovery_eligibility("2004 BMW M3 Coupe", "CA") == (
+        False,
+        "listing outside US",
+    )
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "2004 Harley-Davidson Motorcycle",
+        "1967 Porsche 911 Literature Collection",
+        "1989 Polaris ATV",
+        "1967 Ford F-250 Fire Truck",
+    ],
+)
+def test_evaluate_discovery_eligibility_keeps_valid_year_and_location_titles_in_scope(title):
+    assert discovery.evaluate_discovery_eligibility(title, "US") == (True, None)
+
+
 def test_discover_completed_auctions_returns_summary_counts_across_pages(mocker):
     fetch_completed_auctions_page = mocker.patch(
         "app.sources.bat.discovery.fetch_completed_auctions_page",

--- a/tests/unit/bat/test_transform.py
+++ b/tests/unit/bat/test_transform.py
@@ -383,6 +383,168 @@ def test_parse_make_not_found():
     soup = BeautifulSoup(html_content, "html.parser")
     with pytest.raises(ValueError, match="Could not find 'Make' group"):
         transform.parse_make(soup)
+
+
+def test_extract_group_value_reads_category_from_group_link():
+    soup = BeautifulSoup(
+        """
+        <html>
+            <body>
+                <a class="group-link" href="/truck-4x4/">
+                    <strong class="group-title-label">Category</strong>
+                    Truck & 4x4
+                </a>
+            </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+    assert transform.extract_group_value(soup, "Category") == "Truck & 4x4"
+
+
+def test_evaluate_listing_eligibility_rejects_missing_or_unparseable_year():
+    soup = BeautifulSoup("<html></html>", "html.parser")
+
+    assert transform.evaluate_listing_eligibility(soup, "Factory Five Cobra Replica") == (
+        False,
+        "title year missing",
+    )
+
+
+def test_evaluate_listing_eligibility_rejects_pre_1946_title():
+    soup = BeautifulSoup("<html></html>", "html.parser")
+
+    assert transform.evaluate_listing_eligibility(soup, "1941 Ford Super Deluxe Coupe") == (
+        False,
+        "year before 1946",
+    )
+
+
+def test_evaluate_listing_eligibility_rejects_excluded_category():
+    soup = BeautifulSoup(
+        """
+        <html>
+            <body>
+                <a class="group-link" href="/parts/">
+                    <strong class="group-title-label">Category</strong>
+                    Parts
+                </a>
+            </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+    assert transform.evaluate_listing_eligibility(soup, "1967 Porsche 911S Coupe") == (
+        False,
+        "excluded category: Parts",
+    )
+
+
+def test_evaluate_listing_eligibility_rejects_projects_via_category():
+    soup = BeautifulSoup(
+        """
+        <html>
+            <body>
+                <a class="group-link" href="/project/">
+                    <strong class="group-title-label">Category</strong>
+                    Projects
+                </a>
+            </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+    assert transform.evaluate_listing_eligibility(soup, "1967 Porsche 911 Coupe") == (
+        False,
+        "excluded category: Projects",
+    )
+
+
+def test_evaluate_listing_eligibility_rejects_race_cars_via_category():
+    soup = BeautifulSoup(
+        """
+        <html>
+            <body>
+                <a class="group-link" href="/race-car/">
+                    <strong class="group-title-label">Category</strong>
+                    Race Cars
+                </a>
+            </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+    assert transform.evaluate_listing_eligibility(soup, "1997 Porsche 911 GT2 Evo") == (
+        False,
+        "excluded category: Race Cars",
+    )
+
+
+def test_evaluate_listing_eligibility_rejects_replica_when_title_year_missing():
+    soup = BeautifulSoup(
+        """
+        <html>
+            <body>
+                <a class="group-link" href="/convertible/">
+                    <strong class="group-title-label">Category</strong>
+                    Convertibles
+                </a>
+            </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+    assert transform.evaluate_listing_eligibility(soup, "Shelby Cobra Replica") == (
+        False,
+        "title year missing",
+    )
+
+
+def test_evaluate_listing_eligibility_does_not_reject_missing_category():
+    soup = BeautifulSoup("<html><body></body></html>", "html.parser")
+
+    assert transform.evaluate_listing_eligibility(soup, "1967 Porsche 911S Coupe") == (True, None)
+
+
+def test_evaluate_listing_eligibility_does_not_reject_non_excluded_category():
+    soup = BeautifulSoup(
+        """
+        <html>
+            <body>
+                <a class="group-link" href="/convertible/">
+                    <strong class="group-title-label">Category</strong>
+                    Convertibles
+                </a>
+            </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+    assert transform.evaluate_listing_eligibility(soup, "1967 Porsche 911S Coupe") == (True, None)
+
+
+def test_evaluate_listing_eligibility_keeps_truck_and_4x4_in_scope():
+    soup = BeautifulSoup(
+        """
+        <html>
+            <body>
+                <a class="group-link" href="/truck-4x4/">
+                    <strong class="group-title-label">Category</strong>
+                    Truck & 4x4
+                </a>
+            </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+    assert transform.evaluate_listing_eligibility(soup, "1967 Ford F-250 4x4") == (True, None)
     
 def test_get_listing_details_valid():
     html_content = """


### PR DESCRIPTION
## Summary
- add a stage-1 BAT discovery eligibility helper that screens only on title year and US source location
- add a stage-2 BAT listing eligibility helper that reuses BAT category parsing and rejects approved excluded categories while keeping missing category fail-open
- add focused unit coverage for the new discovery and transform eligibility helpers

## Verification
- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_discovery.py`
- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_transform.py`
