### PR TITLE
Add batch orchestration and CLI for discovered BAT HTML ingest

### DIFF
--- a/app/sources/bat/cli.py
+++ b/app/sources/bat/cli.py
@@ -1,17 +1,41 @@
 import argparse
 import logging
+from dataclasses import dataclass
 from datetime import date
 
+from bs4 import BeautifulSoup
 from dotenv import load_dotenv
 
-from app.sources.bat.discovery import discover_completed_auctions
+from app.sources.bat.discovery import (
+    discover_completed_auctions,
+    evaluate_discovery_eligibility,
+    load_pending_discovered_listings,
+    mark_discovered_listing_handled_eligible,
+    mark_discovered_listing_handled_ineligible,
+)
 from app.sources.bat.ingest import fetch_listing_html, save_listing_html
 from app.sources.bat.load import load_listing
-from app.sources.bat.transform import transform_listing_html
+from app.sources.bat.transform import (
+    evaluate_listing_eligibility,
+    extract_listing_title,
+    get_product_json_ld,
+    transform_listing_html,
+)
 
 load_dotenv()
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BatchIngestSummary:
+    selected: int = 0
+    stage_1_rejected: int = 0
+    scrape_attempted: int = 0
+    scrape_failed: int = 0
+    stage_2_rejected: int = 0
+    raw_html_stored: int = 0
+    accepted: int = 0
 
 
 def build_parser():
@@ -29,6 +53,9 @@ def build_parser():
         default=date.today(),
     )
     discover_parser.add_argument("--max-candidates", type=int)
+
+    ingest_discovered_parser = subparsers.add_parser("ingest-discovered")
+    ingest_discovered_parser.add_argument("--batch-size", type=int)
 
     return parser
 
@@ -67,6 +94,49 @@ def discover_listings(scrape_date, max_candidates=None):
     )
 
 
+def ingest_discovered_listings(batch_size=None):
+    summary = BatchIngestSummary()
+    pending_rows = load_pending_discovered_listings(limit=batch_size)
+
+    for row in pending_rows:
+        summary.selected += 1
+        listing_id = row["source_listing_id"]
+        eligible, reason = evaluate_discovery_eligibility(
+            row.get("title"),
+            row.get("source_location"),
+        )
+        if not eligible:
+            mark_discovered_listing_handled_ineligible(listing_id, reason)
+            summary.stage_1_rejected += 1
+            continue
+
+        summary.scrape_attempted += 1
+        try:
+            html = fetch_listing_html(listing_id)
+        except Exception:
+            summary.scrape_failed += 1
+            logger.error("BAT ingest-discovered scrape failed for listing_id=%s", listing_id)
+            continue
+
+        soup = BeautifulSoup(html, "html.parser")
+        listing_title = row.get("title")
+        if not listing_title:
+            listing_title = extract_listing_title(soup, get_product_json_ld(soup))
+
+        eligible, reason = evaluate_listing_eligibility(soup, listing_title)
+        if not eligible:
+            mark_discovered_listing_handled_ineligible(listing_id, reason)
+            summary.stage_2_rejected += 1
+            continue
+
+        save_listing_html(listing_id, html, url=row["url"])
+        summary.raw_html_stored += 1
+        mark_discovered_listing_handled_eligible(listing_id)
+        summary.accepted += 1
+
+    return summary
+
+
 def main(argv=None):
     configure_logging()
     args = build_parser().parse_args(argv)
@@ -101,6 +171,34 @@ def main(argv=None):
                 args.scrape_date.isoformat(),
             )
             return
+        if args.command == "ingest-discovered":
+            logger.info(
+                "BAT ingest-discovered command started for batch_size=%s",
+                args.batch_size,
+            )
+            summary = ingest_discovered_listings(batch_size=args.batch_size)
+            logger.info(
+                "BAT ingest-discovered summary selected=%s stage_1_rejected=%s scrape_attempted=%s scrape_failed=%s stage_2_rejected=%s raw_html_stored=%s accepted=%s",
+                summary.selected,
+                summary.stage_1_rejected,
+                summary.scrape_attempted,
+                summary.scrape_failed,
+                summary.stage_2_rejected,
+                summary.raw_html_stored,
+                summary.accepted,
+            )
+            print(
+                "Ingest-discovered summary: "
+                f"selected={summary.selected} "
+                f"stage_1_rejected={summary.stage_1_rejected} "
+                f"scrape_attempted={summary.scrape_attempted} "
+                f"scrape_failed={summary.scrape_failed} "
+                f"stage_2_rejected={summary.stage_2_rejected} "
+                f"raw_html_stored={summary.raw_html_stored} "
+                f"accepted={summary.accepted}"
+            )
+            logger.info("BAT ingest-discovered command completed for batch_size=%s", args.batch_size)
+            return
 
         logger.info("BAT %s command started for listing_id=%s", args.command, args.listing_id)
         if args.command == "ingest":
@@ -116,6 +214,11 @@ def main(argv=None):
             logger.error(
                 "BAT discover command failed for scrape_date=%s",
                 args.scrape_date.isoformat(),
+            )
+        elif args.command == "ingest-discovered":
+            logger.error(
+                "BAT ingest-discovered command failed for batch_size=%s",
+                args.batch_size,
             )
         else:
             logger.error("BAT %s command failed for listing_id=%s", args.command, args.listing_id)

--- a/tests/unit/bat/test_cli.py
+++ b/tests/unit/bat/test_cli.py
@@ -168,6 +168,350 @@ def test_discover_command_rejects_results_url_option(capsys):
     assert "--results-url" in capsys.readouterr().err
 
 
+def test_ingest_discovered_command_parses_without_batch_size():
+    args = cli.build_parser().parse_args(["ingest-discovered"])
+
+    assert args.command == "ingest-discovered"
+    assert args.batch_size is None
+
+
+def test_ingest_discovered_command_parses_with_batch_size():
+    args = cli.build_parser().parse_args(["ingest-discovered", "--batch-size", "5"])
+
+    assert args.command == "ingest-discovered"
+    assert args.batch_size == 5
+
+
+def test_ingest_discovered_command_dispatches_with_parsed_options(mocker, caplog, capsys):
+    ingest_discovered_listings = mocker.patch(
+        "app.sources.bat.cli.ingest_discovered_listings",
+        return_value=cli.BatchIngestSummary(
+            selected=3,
+            stage_1_rejected=1,
+            scrape_attempted=2,
+            scrape_failed=1,
+            stage_2_rejected=0,
+            raw_html_stored=1,
+            accepted=1,
+        ),
+    )
+
+    caplog.set_level(logging.INFO)
+    cli.main(["ingest-discovered", "--batch-size", "5"])
+
+    ingest_discovered_listings.assert_called_once_with(batch_size=5)
+    assert "BAT ingest-discovered command started for batch_size=5" in caplog.text
+    assert (
+        "BAT ingest-discovered summary selected=3 stage_1_rejected=1 scrape_attempted=2 "
+        "scrape_failed=1 stage_2_rejected=0 raw_html_stored=1 accepted=1"
+    ) in caplog.text
+    assert "BAT ingest-discovered command completed for batch_size=5" in caplog.text
+    assert (
+        "Ingest-discovered summary: selected=3 stage_1_rejected=1 scrape_attempted=2 "
+        "scrape_failed=1 stage_2_rejected=0 raw_html_stored=1 accepted=1"
+    ) in capsys.readouterr().out
+
+
+def test_ingest_discovered_command_logs_failure_context_without_traceback_and_reraises(
+    mocker, caplog
+):
+    error = RuntimeError("ingest-discovered failed")
+    mocker.patch(
+        "app.sources.bat.cli.ingest_discovered_listings",
+        side_effect=error,
+    )
+
+    caplog.set_level(logging.INFO)
+    with pytest.raises(RuntimeError) as exc_info:
+        cli.main(["ingest-discovered", "--batch-size", "5"])
+
+    assert exc_info.value is error
+    assert "BAT ingest-discovered command started for batch_size=5" in caplog.text
+    assert "BAT ingest-discovered command failed for batch_size=5" in caplog.text
+    assert "Traceback" not in caplog.text
+    assert "RuntimeError: ingest-discovered failed" not in caplog.text
+
+
+def test_ingest_discovered_listings_returns_zeroed_summary_for_empty_batch(mocker):
+    mocker.patch(
+        "app.sources.bat.cli.load_pending_discovered_listings",
+        return_value=[],
+    )
+
+    summary = cli.ingest_discovered_listings()
+
+    assert summary == cli.BatchIngestSummary()
+
+
+def test_ingest_discovered_listings_marks_stage_1_reject_without_scrape(mocker):
+    mocker.patch(
+        "app.sources.bat.cli.load_pending_discovered_listings",
+        return_value=[
+            {
+                "source_listing_id": "stage-1-reject",
+                "title": "1940 Ford Coupe",
+                "source_location": "US",
+                "url": "https://bringatrailer.com/listing/stage-1-reject/",
+            }
+        ],
+    )
+    mocker.patch(
+        "app.sources.bat.cli.evaluate_discovery_eligibility",
+        return_value=(False, "year before 1946"),
+    )
+    mark_ineligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_ineligible")
+    fetch_listing_html = mocker.patch("app.sources.bat.cli.fetch_listing_html")
+
+    summary = cli.ingest_discovered_listings()
+
+    mark_ineligible.assert_called_once_with("stage-1-reject", "year before 1946")
+    fetch_listing_html.assert_not_called()
+    assert summary == cli.BatchIngestSummary(
+        selected=1,
+        stage_1_rejected=1,
+    )
+
+
+def test_ingest_discovered_listings_records_scrape_failure_without_marking_row(mocker):
+    mocker.patch(
+        "app.sources.bat.cli.load_pending_discovered_listings",
+        return_value=[
+            {
+                "source_listing_id": "scrape-fail",
+                "title": "1967 Porsche 911S Coupe",
+                "source_location": "US",
+                "url": "https://bringatrailer.com/listing/scrape-fail/",
+            }
+        ],
+    )
+    mocker.patch(
+        "app.sources.bat.cli.evaluate_discovery_eligibility",
+        return_value=(True, None),
+    )
+    mocker.patch(
+        "app.sources.bat.cli.fetch_listing_html",
+        side_effect=RuntimeError("network failed"),
+    )
+    mark_ineligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_ineligible")
+    mark_eligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_eligible")
+
+    summary = cli.ingest_discovered_listings()
+
+    mark_ineligible.assert_not_called()
+    mark_eligible.assert_not_called()
+    assert summary == cli.BatchIngestSummary(
+        selected=1,
+        scrape_attempted=1,
+        scrape_failed=1,
+    )
+
+
+def test_ingest_discovered_listings_marks_stage_2_reject_without_saving_html(mocker):
+    mocker.patch(
+        "app.sources.bat.cli.load_pending_discovered_listings",
+        return_value=[
+            {
+                "source_listing_id": "stage-2-reject",
+                "title": "1967 Porsche 911S Coupe",
+                "source_location": "US",
+                "url": "https://bringatrailer.com/listing/stage-2-reject/",
+            }
+        ],
+    )
+    mocker.patch(
+        "app.sources.bat.cli.evaluate_discovery_eligibility",
+        return_value=(True, None),
+    )
+    mocker.patch(
+        "app.sources.bat.cli.fetch_listing_html",
+        return_value="<html><body>listing</body></html>",
+    )
+    mocker.patch(
+        "app.sources.bat.cli.evaluate_listing_eligibility",
+        return_value=(False, "excluded category: projects"),
+    )
+    mark_ineligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_ineligible")
+    save_listing_html = mocker.patch("app.sources.bat.cli.save_listing_html")
+
+    summary = cli.ingest_discovered_listings()
+
+    mark_ineligible.assert_called_once_with("stage-2-reject", "excluded category: projects")
+    save_listing_html.assert_not_called()
+    assert summary == cli.BatchIngestSummary(
+        selected=1,
+        scrape_attempted=1,
+        stage_2_rejected=1,
+    )
+
+
+def test_ingest_discovered_listings_saves_html_and_marks_eligible_for_stage_2_pass(mocker):
+    mocker.patch(
+        "app.sources.bat.cli.load_pending_discovered_listings",
+        return_value=[
+            {
+                "source_listing_id": "accepted",
+                "title": "1967 Porsche 911S Coupe",
+                "source_location": "US",
+                "url": "https://bringatrailer.com/listing/accepted/",
+            }
+        ],
+    )
+    mocker.patch(
+        "app.sources.bat.cli.evaluate_discovery_eligibility",
+        return_value=(True, None),
+    )
+    mocker.patch(
+        "app.sources.bat.cli.fetch_listing_html",
+        return_value="<html><body>listing</body></html>",
+    )
+    mocker.patch(
+        "app.sources.bat.cli.evaluate_listing_eligibility",
+        return_value=(True, None),
+    )
+    save_listing_html = mocker.patch("app.sources.bat.cli.save_listing_html")
+    mark_eligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_eligible")
+
+    summary = cli.ingest_discovered_listings()
+
+    save_listing_html.assert_called_once_with(
+        "accepted",
+        "<html><body>listing</body></html>",
+        url="https://bringatrailer.com/listing/accepted/",
+    )
+    mark_eligible.assert_called_once_with("accepted")
+    assert summary == cli.BatchIngestSummary(
+        selected=1,
+        scrape_attempted=1,
+        raw_html_stored=1,
+        accepted=1,
+    )
+
+
+def test_ingest_discovered_listings_uses_html_title_fallback_when_discovered_title_missing(mocker):
+    mocker.patch(
+        "app.sources.bat.cli.load_pending_discovered_listings",
+        return_value=[
+            {
+                "source_listing_id": "fallback-title",
+                "title": None,
+                "source_location": "US",
+                "url": "https://bringatrailer.com/listing/fallback-title/",
+            }
+        ],
+    )
+    mocker.patch(
+        "app.sources.bat.cli.evaluate_discovery_eligibility",
+        return_value=(True, None),
+    )
+    mocker.patch(
+        "app.sources.bat.cli.fetch_listing_html",
+        return_value="<html><body>listing</body></html>",
+    )
+    get_product_json_ld = mocker.patch(
+        "app.sources.bat.cli.get_product_json_ld",
+        return_value={"name": "1967 Porsche 911S Coupe"},
+    )
+    extract_listing_title = mocker.patch(
+        "app.sources.bat.cli.extract_listing_title",
+        return_value="1967 Porsche 911S Coupe",
+    )
+    evaluate_listing_eligibility = mocker.patch(
+        "app.sources.bat.cli.evaluate_listing_eligibility",
+        return_value=(True, None),
+    )
+    mocker.patch("app.sources.bat.cli.save_listing_html")
+    mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_eligible")
+
+    cli.ingest_discovered_listings()
+
+    get_product_json_ld.assert_called_once()
+    extract_listing_title.assert_called_once()
+    evaluate_listing_eligibility.assert_called_once()
+    _, listing_title = evaluate_listing_eligibility.call_args.args
+    assert listing_title == "1967 Porsche 911S Coupe"
+
+
+def test_ingest_discovered_listings_handles_mixed_batch_outcomes(mocker):
+    mocker.patch(
+        "app.sources.bat.cli.load_pending_discovered_listings",
+        return_value=[
+            {
+                "source_listing_id": "stage-1-reject",
+                "title": "1940 Ford Coupe",
+                "source_location": "US",
+                "url": "https://bringatrailer.com/listing/stage-1-reject/",
+            },
+            {
+                "source_listing_id": "scrape-fail",
+                "title": "1967 Porsche 911S Coupe",
+                "source_location": "US",
+                "url": "https://bringatrailer.com/listing/scrape-fail/",
+            },
+            {
+                "source_listing_id": "stage-2-reject",
+                "title": "1969 Porsche 911E Coupe",
+                "source_location": "US",
+                "url": "https://bringatrailer.com/listing/stage-2-reject/",
+            },
+            {
+                "source_listing_id": "accepted",
+                "title": "1970 Porsche 911T Coupe",
+                "source_location": "US",
+                "url": "https://bringatrailer.com/listing/accepted/",
+            },
+        ],
+    )
+    mocker.patch(
+        "app.sources.bat.cli.evaluate_discovery_eligibility",
+        side_effect=[
+            (False, "year before 1946"),
+            (True, None),
+            (True, None),
+            (True, None),
+        ],
+    )
+    mocker.patch(
+        "app.sources.bat.cli.fetch_listing_html",
+        side_effect=[
+            RuntimeError("network failed"),
+            "<html><body>stage-2 reject</body></html>",
+            "<html><body>accepted</body></html>",
+        ],
+    )
+    mocker.patch(
+        "app.sources.bat.cli.evaluate_listing_eligibility",
+        side_effect=[
+            (False, "excluded category: projects"),
+            (True, None),
+        ],
+    )
+    save_listing_html = mocker.patch("app.sources.bat.cli.save_listing_html")
+    mark_ineligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_ineligible")
+    mark_eligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_eligible")
+
+    summary = cli.ingest_discovered_listings()
+
+    assert summary == cli.BatchIngestSummary(
+        selected=4,
+        stage_1_rejected=1,
+        scrape_attempted=3,
+        scrape_failed=1,
+        stage_2_rejected=1,
+        raw_html_stored=1,
+        accepted=1,
+    )
+    assert mark_ineligible.call_args_list == [
+        mocker.call("stage-1-reject", "year before 1946"),
+        mocker.call("stage-2-reject", "excluded category: projects"),
+    ]
+    save_listing_html.assert_called_once_with(
+        "accepted",
+        "<html><body>accepted</body></html>",
+        url="https://bringatrailer.com/listing/accepted/",
+    )
+    mark_eligible.assert_called_once_with("accepted")
+
+
 @pytest.mark.parametrize("command", ["ingest", "transform", "load", "run"])
 def test_commands_require_listing_id(command, capsys):
     with pytest.raises(SystemExit) as exc_info:


### PR DESCRIPTION
## Summary
- add an `ingest-discovered` BAT CLI command with optional batch sizing
- orchestrate pending discovered BAT listings through stage-1 filtering, scraping, stage-2 filtering, raw HTML persistence, and eligibility updates
- add focused CLI unit coverage for parser behavior, mixed batch outcomes, and summary reporting

## Verification
- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_cli.py`
