### PR TITLE
Implement BAT transform-discovered batch transform-and-load

### DIFF
--- a/app/sources/bat/cli.py
+++ b/app/sources/bat/cli.py
@@ -19,6 +19,7 @@ from app.sources.bat.transform import (
     evaluate_listing_eligibility,
     extract_listing_title,
     get_product_json_ld,
+    load_pending_raw_listing_html,
     transform_listing_html,
 )
 
@@ -36,6 +37,14 @@ class BatchIngestSummary:
     stage_2_rejected: int = 0
     raw_html_stored: int = 0
     accepted: int = 0
+
+
+@dataclass
+class BatchTransformSummary:
+    selected: int = 0
+    transformed_and_loaded: int = 0
+    transform_failed: int = 0
+    load_failed: int = 0
 
 
 def build_parser():
@@ -56,6 +65,9 @@ def build_parser():
 
     ingest_discovered_parser = subparsers.add_parser("ingest-discovered")
     ingest_discovered_parser.add_argument("--batch-size", type=int)
+
+    transform_discovered_parser = subparsers.add_parser("transform-discovered")
+    transform_discovered_parser.add_argument("--batch-size", type=int)
 
     return parser
 
@@ -137,6 +149,41 @@ def ingest_discovered_listings(batch_size=None):
     return summary
 
 
+def transform_discovered_listings(batch_size=None):
+    summary = BatchTransformSummary()
+    pending_rows = load_pending_raw_listing_html(limit=batch_size)
+
+    for row in pending_rows:
+        summary.selected += 1
+        listing_id = row["source_listing_id"]
+
+        try:
+            transformed_listing = transform_listing_html(listing_id)
+        except Exception as exc:
+            summary.transform_failed += 1
+            logger.error(
+                "BAT transform-discovered row failed for listing_id=%s stage=transform error=%s",
+                listing_id,
+                exc,
+            )
+            continue
+
+        try:
+            load_listing(transformed_listing)
+        except Exception as exc:
+            summary.load_failed += 1
+            logger.error(
+                "BAT transform-discovered row failed for listing_id=%s stage=load error=%s",
+                listing_id,
+                exc,
+            )
+            continue
+
+        summary.transformed_and_loaded += 1
+
+    return summary
+
+
 def main(argv=None):
     configure_logging()
     args = build_parser().parse_args(argv)
@@ -199,6 +246,31 @@ def main(argv=None):
             )
             logger.info("BAT ingest-discovered command completed for batch_size=%s", args.batch_size)
             return
+        if args.command == "transform-discovered":
+            logger.info(
+                "BAT transform-discovered command started for batch_size=%s",
+                args.batch_size,
+            )
+            summary = transform_discovered_listings(batch_size=args.batch_size)
+            logger.info(
+                "BAT transform-discovered summary selected=%s transformed_and_loaded=%s transform_failed=%s load_failed=%s",
+                summary.selected,
+                summary.transformed_and_loaded,
+                summary.transform_failed,
+                summary.load_failed,
+            )
+            print(
+                "Transform-discovered summary: "
+                f"selected={summary.selected} "
+                f"transformed_and_loaded={summary.transformed_and_loaded} "
+                f"transform_failed={summary.transform_failed} "
+                f"load_failed={summary.load_failed}"
+            )
+            logger.info(
+                "BAT transform-discovered command completed for batch_size=%s",
+                args.batch_size,
+            )
+            return
 
         logger.info("BAT %s command started for listing_id=%s", args.command, args.listing_id)
         if args.command == "ingest":
@@ -218,6 +290,11 @@ def main(argv=None):
         elif args.command == "ingest-discovered":
             logger.error(
                 "BAT ingest-discovered command failed for batch_size=%s",
+                args.batch_size,
+            )
+        elif args.command == "transform-discovered":
+            logger.error(
+                "BAT transform-discovered command failed for batch_size=%s",
                 args.batch_size,
             )
         else:

--- a/app/sources/bat/transform.py
+++ b/app/sources/bat/transform.py
@@ -5,6 +5,7 @@ import re
 from datetime import datetime
 from bs4 import BeautifulSoup
 import psycopg
+from psycopg.rows import dict_row
 
 
 SOURCE_SITE = "bringatrailer"
@@ -38,6 +39,21 @@ WHERE source_site = %(source_site)s
   AND source_listing_id = %(source_listing_id)s
 """
 
+SELECT_PENDING_RAW_LISTING_HTML_SQL = """
+SELECT
+    id,
+    source_site,
+    source_listing_id,
+    url,
+    raw_html,
+    created_at,
+    processed
+FROM raw_listing_html
+WHERE source_site = %(source_site)s
+  AND processed = FALSE
+ORDER BY created_at ASC, id ASC
+"""
+
 TRANSMISSION_DETAIL_PATTERN = (
     r"\b(?:Transmission|Transaxle|Gearbox)\b"
     r"|"
@@ -68,6 +84,26 @@ def build_raw_listing_lookup_params(listing_id):
         "source_site": SOURCE_SITE,
         "source_listing_id": listing_id,
     }
+
+
+def load_pending_raw_listing_html(limit=None):
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set")
+
+    params = {"source_site": SOURCE_SITE}
+    sql = SELECT_PENDING_RAW_LISTING_HTML_SQL
+
+    if limit is not None:
+        if limit <= 0:
+            return []
+        sql = f"{sql}\nLIMIT %(limit)s"
+        params["limit"] = limit
+
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(sql, params)
+            return cur.fetchall()
 
 
 def transform_listing_html(listing_id):

--- a/tests/integration/bat/test_transform_discovered_integration.py
+++ b/tests/integration/bat/test_transform_discovered_integration.py
@@ -1,0 +1,268 @@
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from app.sources.bat import cli
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = REPO_ROOT / "app" / "db" / "schema.sql"
+VALID_RAW_HTML = """
+<html>
+    <head>
+        <script type="application/ld+json">
+        {
+            "@context": "http://schema.org",
+            "@type": "Product",
+            "name": "2004 BMW E46 M3",
+            "offers": {
+                "@type": "Offer",
+                "priceCurrency": "USD",
+                "price": 19750
+            }
+        }
+        </script>
+    </head>
+    <body>
+        <button class="group-title">
+            <strong class="group-title-label">Make</strong>
+            BMW
+        </button>
+        <button class="group-title">
+            <strong class="group-title-label">Model</strong>
+            BMW E46 M3
+        </button>
+        <div class="item">
+            <strong>Listing Details</strong>
+            <ul>
+                <li>Chassis: WBSBL93414PN57203</li>
+                <li>178k Miles</li>
+                <li>Six-Speed Manual Transmission</li>
+            </ul>
+        </div>
+        <div class="listing-available">
+            <div class="listing-available-info">
+                <span class="info-value noborder-tiny">
+                    Sold for <strong>USD $19,750</strong>
+                </span>
+            </div>
+            <span class="date date-localize" data-timestamp="1774898451"></span>
+        </div>
+    </body>
+</html>
+"""
+
+
+def test_transform_discovered_processes_successes_retains_failures_and_respects_batch_size(
+    monkeypatch,
+):
+    if not _docker_daemon_available():
+        pytest.skip("Docker daemon is not available")
+
+    container_name = f"auction-transform-discovered-test-{uuid.uuid4().hex}"
+    schema_mount = f"{SCHEMA_PATH}:/docker-entrypoint-initdb.d/001-schema.sql:ro"
+
+    try:
+        _run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "-d",
+                "--name",
+                container_name,
+                "-e",
+                "POSTGRES_DB=auction_etl",
+                "-e",
+                "POSTGRES_USER=auction_user",
+                "-e",
+                "POSTGRES_PASSWORD=localdevpassword",
+                "-p",
+                "127.0.0.1::5432",
+                "-v",
+                schema_mount,
+                "postgres:17",
+            ]
+        )
+        _wait_for_postgres(container_name)
+
+        port = _host_port(container_name)
+        database_url = (
+            f"postgresql://auction_user:localdevpassword@127.0.0.1:{port}/auction_etl"
+        )
+        _wait_for_database_url(database_url)
+        monkeypatch.setenv("DATABASE_URL", database_url)
+        _insert_raw_listing_rows(database_url)
+
+        first_summary = cli.transform_discovered_listings(batch_size=2)
+        assert first_summary == cli.BatchTransformSummary(
+            selected=2,
+            transformed_and_loaded=1,
+            transform_failed=1,
+            load_failed=0,
+        )
+
+        assert _raw_processed_states(database_url) == [
+            ("first-success", True),
+            ("second-success", False),
+            ("transform-fail", False),
+        ]
+        assert _listing_ids(database_url) == ["first-success"]
+
+        second_summary = cli.transform_discovered_listings()
+        assert second_summary == cli.BatchTransformSummary(
+            selected=2,
+            transformed_and_loaded=1,
+            transform_failed=1,
+            load_failed=0,
+        )
+
+        assert _raw_processed_states(database_url) == [
+            ("first-success", True),
+            ("second-success", True),
+            ("transform-fail", False),
+        ]
+        assert _listing_ids(database_url) == ["first-success", "second-success"]
+    finally:
+        subprocess.run(["docker", "rm", "-f", container_name], capture_output=True, text=True)
+
+
+def _insert_raw_listing_rows(database_url):
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO raw_listing_html (
+                    id,
+                    source_site,
+                    source_listing_id,
+                    url,
+                    raw_html,
+                    created_at,
+                    processed
+                ) VALUES
+                    (
+                        10,
+                        'bringatrailer',
+                        'first-success',
+                        'https://bringatrailer.com/listing/first-success/',
+                        %s,
+                        TIMESTAMPTZ '2026-04-20 08:00:00+00',
+                        FALSE
+                    ),
+                    (
+                        20,
+                        'bringatrailer',
+                        'transform-fail',
+                        'https://bringatrailer.com/listing/transform-fail/',
+                        '<html><body>broken</body></html>',
+                        TIMESTAMPTZ '2026-04-20 08:00:00+00',
+                        FALSE
+                    ),
+                    (
+                        30,
+                        'bringatrailer',
+                        'second-success',
+                        'https://bringatrailer.com/listing/second-success/',
+                        %s,
+                        TIMESTAMPTZ '2026-04-20 09:00:00+00',
+                        FALSE
+                    )
+                """,
+                (VALID_RAW_HTML, VALID_RAW_HTML),
+            )
+
+
+def _raw_processed_states(database_url):
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT source_listing_id, processed
+                FROM raw_listing_html
+                WHERE source_site = 'bringatrailer'
+                ORDER BY source_listing_id ASC
+                """
+            )
+            return cur.fetchall()
+
+
+def _listing_ids(database_url):
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT source_listing_id
+                FROM listings
+                WHERE source_site = 'bringatrailer'
+                ORDER BY source_listing_id ASC
+                """
+            )
+            return [row[0] for row in cur.fetchall()]
+
+
+def _docker_daemon_available():
+    try:
+        result = subprocess.run(["docker", "info"], capture_output=True, text=True)
+    except FileNotFoundError:
+        return False
+    return result.returncode == 0
+
+
+def _wait_for_postgres(container_name):
+    deadline = time.monotonic() + 30
+    last_error = ""
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            [
+                "docker",
+                "exec",
+                container_name,
+                "psql",
+                "-U",
+                "auction_user",
+                "-d",
+                "auction_etl",
+                "-t",
+                "-A",
+                "-c",
+                "SELECT 1;",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return
+        last_error = result.stderr or result.stdout
+        time.sleep(1)
+
+    pytest.fail(f"Postgres did not become ready: {last_error}")
+
+
+def _host_port(container_name):
+    result = _run(["docker", "port", container_name, "5432/tcp"])
+    return result.stdout.rsplit(":", maxsplit=1)[-1].strip()
+
+
+def _wait_for_database_url(database_url):
+    deadline = time.monotonic() + 30
+    last_error = ""
+    while time.monotonic() < deadline:
+        try:
+            with psycopg.connect(database_url) as conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT 1;")
+            return
+        except psycopg.OperationalError as exc:
+            last_error = str(exc)
+            time.sleep(1)
+
+    pytest.fail(f"Postgres host connection did not become ready: {last_error}")
+
+
+def _run(command):
+    return subprocess.run(command, capture_output=True, text=True, check=True)

--- a/tests/unit/bat/test_cli.py
+++ b/tests/unit/bat/test_cli.py
@@ -182,6 +182,20 @@ def test_ingest_discovered_command_parses_with_batch_size():
     assert args.batch_size == 5
 
 
+def test_transform_discovered_command_parses_without_batch_size():
+    args = cli.build_parser().parse_args(["transform-discovered"])
+
+    assert args.command == "transform-discovered"
+    assert args.batch_size is None
+
+
+def test_transform_discovered_command_parses_with_batch_size():
+    args = cli.build_parser().parse_args(["transform-discovered", "--batch-size", "5"])
+
+    assert args.command == "transform-discovered"
+    assert args.batch_size == 5
+
+
 def test_ingest_discovered_command_dispatches_with_parsed_options(mocker, caplog, capsys):
     ingest_discovered_listings = mocker.patch(
         "app.sources.bat.cli.ingest_discovered_listings",
@@ -232,6 +246,53 @@ def test_ingest_discovered_command_logs_failure_context_without_traceback_and_re
     assert "RuntimeError: ingest-discovered failed" not in caplog.text
 
 
+def test_transform_discovered_command_dispatches_with_parsed_options(mocker, caplog, capsys):
+    transform_discovered_listings = mocker.patch(
+        "app.sources.bat.cli.transform_discovered_listings",
+        return_value=cli.BatchTransformSummary(
+            selected=3,
+            transformed_and_loaded=1,
+            transform_failed=1,
+            load_failed=1,
+        ),
+    )
+
+    caplog.set_level(logging.INFO)
+    cli.main(["transform-discovered", "--batch-size", "5"])
+
+    transform_discovered_listings.assert_called_once_with(batch_size=5)
+    assert "BAT transform-discovered command started for batch_size=5" in caplog.text
+    assert (
+        "BAT transform-discovered summary selected=3 transformed_and_loaded=1 "
+        "transform_failed=1 load_failed=1"
+    ) in caplog.text
+    assert "BAT transform-discovered command completed for batch_size=5" in caplog.text
+    assert (
+        "Transform-discovered summary: selected=3 transformed_and_loaded=1 "
+        "transform_failed=1 load_failed=1"
+    ) in capsys.readouterr().out
+
+
+def test_transform_discovered_command_logs_failure_context_without_traceback_and_reraises(
+    mocker, caplog
+):
+    error = RuntimeError("transform-discovered failed")
+    mocker.patch(
+        "app.sources.bat.cli.transform_discovered_listings",
+        side_effect=error,
+    )
+
+    caplog.set_level(logging.INFO)
+    with pytest.raises(RuntimeError) as exc_info:
+        cli.main(["transform-discovered", "--batch-size", "5"])
+
+    assert exc_info.value is error
+    assert "BAT transform-discovered command started for batch_size=5" in caplog.text
+    assert "BAT transform-discovered command failed for batch_size=5" in caplog.text
+    assert "Traceback" not in caplog.text
+    assert "RuntimeError: transform-discovered failed" not in caplog.text
+
+
 def test_ingest_discovered_listings_returns_zeroed_summary_for_empty_batch(mocker):
     mocker.patch(
         "app.sources.bat.cli.load_pending_discovered_listings",
@@ -241,6 +302,17 @@ def test_ingest_discovered_listings_returns_zeroed_summary_for_empty_batch(mocke
     summary = cli.ingest_discovered_listings()
 
     assert summary == cli.BatchIngestSummary()
+
+
+def test_transform_discovered_listings_returns_zeroed_summary_for_empty_batch(mocker):
+    mocker.patch(
+        "app.sources.bat.cli.load_pending_raw_listing_html",
+        return_value=[],
+    )
+
+    summary = cli.transform_discovered_listings()
+
+    assert summary == cli.BatchTransformSummary()
 
 
 def test_ingest_discovered_listings_marks_stage_1_reject_without_scrape(mocker):
@@ -510,6 +582,59 @@ def test_ingest_discovered_listings_handles_mixed_batch_outcomes(mocker):
         url="https://bringatrailer.com/listing/accepted/",
     )
     mark_eligible.assert_called_once_with("accepted")
+
+
+def test_transform_discovered_listings_handles_mixed_batch_outcomes(mocker, caplog):
+    mocker.patch(
+        "app.sources.bat.cli.load_pending_raw_listing_html",
+        return_value=[
+            {"source_listing_id": "transform-fail"},
+            {"source_listing_id": "load-fail"},
+            {"source_listing_id": "success"},
+        ],
+    )
+    transformed_load_fail = {"listing_id": "load-fail"}
+    transformed_success = {"listing_id": "success"}
+    mocker.patch(
+        "app.sources.bat.cli.transform_listing_html",
+        side_effect=[
+            RuntimeError("missing raw html"),
+            transformed_load_fail,
+            transformed_success,
+        ],
+    )
+    load_listing = mocker.patch(
+        "app.sources.bat.cli.load_listing",
+        side_effect=[
+            RuntimeError("constraint violation"),
+            None,
+        ],
+    )
+
+    caplog.set_level(logging.ERROR)
+    summary = cli.transform_discovered_listings(batch_size=3)
+
+    load_listing.assert_has_calls(
+        [
+            mocker.call(transformed_load_fail),
+            mocker.call(transformed_success),
+        ]
+    )
+    assert summary == cli.BatchTransformSummary(
+        selected=3,
+        transformed_and_loaded=1,
+        transform_failed=1,
+        load_failed=1,
+    )
+    assert (
+        "BAT transform-discovered row failed for listing_id=transform-fail "
+        "stage=transform error=missing raw html"
+    ) in caplog.text
+    assert (
+        "BAT transform-discovered row failed for listing_id=load-fail "
+        "stage=load error=constraint violation"
+    ) in caplog.text
+    assert "Traceback" not in caplog.text
 
 
 @pytest.mark.parametrize("command", ["ingest", "transform", "load", "run"])

--- a/tests/unit/bat/test_transform.py
+++ b/tests/unit/bat/test_transform.py
@@ -105,6 +105,116 @@ def test_load_listing_html_requires_database_url(mocker):
         transform.load_listing_html("test-id")
 
 
+def test_load_pending_raw_listing_html_selects_unprocessed_rows_in_stable_order(mocker):
+    calls = {}
+    expected_rows = [
+        {"source_listing_id": "first"},
+        {"source_listing_id": "second"},
+    ]
+
+    class FakeCursor:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            calls["sql"] = sql
+            calls["params"] = params
+
+        def fetchall(self):
+            return self._rows
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self, row_factory=None):
+            calls["row_factory"] = row_factory
+            return FakeCursor(expected_rows)
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    mocker.patch.object(transform.psycopg, "connect", return_value=FakeConnection())
+
+    rows = transform.load_pending_raw_listing_html()
+
+    assert rows == expected_rows
+    assert "FROM raw_listing_html" in calls["sql"]
+    assert "processed = FALSE" in calls["sql"]
+    assert "ORDER BY created_at ASC, id ASC" in calls["sql"]
+    assert "LIMIT %(limit)s" not in calls["sql"]
+    assert calls["params"] == {"source_site": "bringatrailer"}
+    assert calls["row_factory"] is transform.dict_row
+
+
+def test_load_pending_raw_listing_html_applies_optional_limit(mocker):
+    calls = {}
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            calls["sql"] = sql
+            calls["params"] = params
+
+        def fetchall(self):
+            return [{"source_listing_id": "first"}]
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self, row_factory=None):
+            return FakeCursor()
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    mocker.patch.object(transform.psycopg, "connect", return_value=FakeConnection())
+
+    rows = transform.load_pending_raw_listing_html(limit=1)
+
+    assert rows == [{"source_listing_id": "first"}]
+    assert "LIMIT %(limit)s" in calls["sql"]
+    assert calls["params"] == {"source_site": "bringatrailer", "limit": 1}
+
+
+def test_load_pending_raw_listing_html_returns_empty_for_non_positive_limit(mocker):
+    connect = mocker.patch.object(transform.psycopg, "connect")
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+
+    assert transform.load_pending_raw_listing_html(limit=0) == []
+    connect.assert_not_called()
+
+
+def test_load_pending_raw_listing_html_requires_database_url(mocker):
+    mocker.patch.dict("os.environ", {}, clear=True)
+
+    with pytest.raises(RuntimeError, match="DATABASE_URL must be set"):
+        transform.load_pending_raw_listing_html()
+
+
 def test_transform_listing_html_logs_success_without_raw_html(mocker, caplog):
     mocker.patch.object(transform, "load_listing_html", return_value="<html>SENSITIVE_RAW_HTML</html>")
     mocker.patch.object(transform, "get_product_json_ld", return_value={"name": "One Owner 2004 BMW M3"})


### PR DESCRIPTION
## Summary
- add the BAT 0transform-discovered0 batch command with pending raw-html queue selection and summary reporting
- process pending raw BAT rows through the existing transform/load flow while continuing after row-level failures
- add unit coverage plus Postgres integration coverage for reruns, failed-row retention, and batch-size limits

## Verification
- .venv\\Scripts\\python.exe -m pytest -q tests\\unit\\bat\\test_cli.py tests\\unit\\bat\\test_load.py tests\\unit\\bat\\test_transform.py
- .venv\\Scripts\\python.exe -m pytest -q tests\\integration\\bat\\test_transform_discovered_integration.py
  - skipped in this environment because Docker was unavailable