### PR TITLE
[codex] Allow listings with missing model labels

### DIFF
--- a/app/db/schema.sql
+++ b/app/db/schema.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS listings (
     source_listing_id TEXT NOT NULL,
     url TEXT NOT NULL,
     make TEXT NOT NULL,
-    model TEXT NOT NULL,
+    model TEXT,
     year INTEGER NOT NULL,
     mileage INTEGER,
     vin TEXT,

--- a/app/sources/bat/transform.py
+++ b/app/sources/bat/transform.py
@@ -154,9 +154,8 @@ def evaluate_listing_eligibility(soup, listing_title):
     if year < BAT_MIN_YEAR:
         return False, "year before 1946"
 
-    try:
-        categories = extract_group_value(soup, "Category")
-    except ValueError:
+    categories = extract_group_value(soup, "Category")
+    if categories is None:
         return True, None
 
     for category in categories:
@@ -209,12 +208,18 @@ def parse_year(title):
     return int(match.group(1))
 
 def parse_model(soup):
-    return extract_group_value(soup, "Model")[0]
+    values = extract_group_value(soup, "Model")
+    if values is None:
+        return None
+    return values[0]
 
 def parse_make(soup):
-    return extract_group_value(soup, "Make")[0]
+    values = extract_group_value(soup, "Make")
+    if values is None:
+        raise ValueError("Could not find 'Make' group")
+    return values[0]
 
-def extract_group_value(soup: BeautifulSoup, label: str) -> list[str]:
+def extract_group_value(soup: BeautifulSoup, label: str) -> list[str] | None:
     values = []
 
     for label_tag in soup.select("strong.group-title-label"):
@@ -233,12 +238,12 @@ def extract_group_value(soup: BeautifulSoup, label: str) -> list[str]:
 
         value = full_text.removeprefix(label_text).strip()
         if not value:
-            raise ValueError(f"Found '{label}' group but it had no value")
+            continue
 
         values.append(value)
 
     if not values:
-        raise ValueError(f"Could not find '{label}' group")
+        return None
 
     return values
 

--- a/tests/integration/test_postgres_schema.py
+++ b/tests/integration/test_postgres_schema.py
@@ -48,14 +48,19 @@ def test_schema_sql_applies_in_isolated_postgres_container():
         column_rows = _psql(
             container_name,
             """
-            SELECT column_name || ':' || data_type
+            SELECT column_name || ':' || data_type || ':' || is_nullable
             FROM information_schema.columns
             WHERE table_name = 'listings'
-              AND column_name IN ('auction_end_date', 'listing_details_raw')
+              AND column_name IN ('auction_end_date', 'listing_details_raw', 'make', 'model')
             ORDER BY column_name;
             """,
         )
-        assert column_rows == ["auction_end_date:date", "listing_details_raw:jsonb"]
+        assert column_rows == [
+            "auction_end_date:date:NO",
+            "listing_details_raw:jsonb:YES",
+            "make:text:NO",
+            "model:text:YES",
+        ]
 
         unique_columns = _psql(
             container_name,

--- a/tests/unit/bat/test_load.py
+++ b/tests/unit/bat/test_load.py
@@ -27,6 +27,15 @@ def test_build_listing_params_maps_transformed_listing_to_schema_columns():
     ]
 
 
+def test_build_listing_params_allows_null_model():
+    transformed_listing = _transformed_listing()
+    transformed_listing["model"] = None
+
+    params = load.build_listing_params(transformed_listing)
+
+    assert params["model"] is None
+
+
 def test_load_listing_executes_upsert_with_expected_conflict_target(mocker, caplog):
     calls = {"executions": []}
 

--- a/tests/unit/bat/test_transform.py
+++ b/tests/unit/bat/test_transform.py
@@ -239,6 +239,50 @@ def test_transform_listing_html_logs_success_without_raw_html(mocker, caplog):
     assert "Transformed BAT listing HTML for listing_id=test-id" in caplog.text
     assert "SENSITIVE_RAW_HTML" not in caplog.text
 
+def test_transform_listing_html_allows_missing_model(mocker):
+    html_content = """
+    <html>
+        <head>
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Product",
+                "name": "One Owner 2004 BMW M3",
+                "offers": {
+                    "@type": "Offer",
+                    "priceCurrency": "USD",
+                    "price": 19750
+                }
+            }
+            </script>
+        </head>
+        <body>
+            <button class="group-title">
+                <strong class="group-title-label">Make</strong>
+                BMW
+            </button>
+            <div class="item">
+                <strong>Listing Details</strong>
+                <ul>
+                    <li>Chassis: WBSBL93414PN57203</li>
+                    <li>50,250 Miles</li>
+                    <li>6-Speed Manual Transmission</li>
+                </ul>
+            </div>
+            <div class="listing-available-info">
+                <span>Sold for <strong>USD $19,750</strong></span>
+            </div>
+            <span class="date date-localize" data-timestamp="1774898451"></span>
+        </body>
+    </html>
+    """
+    mocker.patch.object(transform, "load_listing_html", return_value=html_content)
+
+    transformed = transform.transform_listing_html("missing-model")
+
+    assert transformed["make"] == "BMW"
+    assert transformed["model"] is None
+
 def test_get_product_json_ld_returns_product_data(tmp_path):
     # create a test HTML file with a valid JSON-LD script tag
     html_content = """
@@ -465,8 +509,20 @@ def test_parse_model_not_found():
     </html>
     """
     soup = BeautifulSoup(html_content, "html.parser")
-    with pytest.raises(ValueError, match="Could not find 'Model' group"):
-        transform.parse_model(soup)
+    assert transform.parse_model(soup) is None
+
+def test_parse_model_empty_group_returns_none():
+    html_content = """
+    <html>
+        <body>
+            <button class="group-title">
+                <strong class="group-title-label">Model</strong>
+            </button>
+        </body>
+    </html>
+    """
+    soup = BeautifulSoup(html_content, "html.parser")
+    assert transform.parse_model(soup) is None
 
 def test_parse_make_valid():
     html_content = """
@@ -532,6 +588,20 @@ def test_parse_make_not_found():
     with pytest.raises(ValueError, match="Could not find 'Make' group"):
         transform.parse_make(soup)
 
+def test_parse_make_empty_group_raises():
+    html_content = """
+    <html>
+        <body>
+            <button class="group-title">
+                <strong class="group-title-label">Make</strong>
+            </button>
+        </body>
+    </html>
+    """
+    soup = BeautifulSoup(html_content, "html.parser")
+    with pytest.raises(ValueError, match="Could not find 'Make' group"):
+        transform.parse_make(soup)
+
 
 def test_extract_group_value_reads_all_category_values_from_group_links():
     soup = BeautifulSoup(
@@ -556,6 +626,27 @@ def test_extract_group_value_reads_all_category_values_from_group_links():
         "Truck & 4x4",
         "Convertibles",
     ]
+
+def test_extract_group_value_returns_none_for_missing_group():
+    soup = BeautifulSoup("<html><body></body></html>", "html.parser")
+
+    assert transform.extract_group_value(soup, "Category") is None
+
+def test_extract_group_value_returns_none_for_empty_group_value():
+    soup = BeautifulSoup(
+        """
+        <html>
+            <body>
+                <button class="group-title">
+                    <strong class="group-title-label">Category</strong>
+                </button>
+            </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+    assert transform.extract_group_value(soup, "Category") is None
 
 
 def test_evaluate_listing_eligibility_rejects_missing_or_unparseable_year():
@@ -686,6 +777,22 @@ def test_evaluate_listing_eligibility_rejects_replica_when_title_year_missing():
 
 def test_evaluate_listing_eligibility_does_not_reject_missing_category():
     soup = BeautifulSoup("<html><body></body></html>", "html.parser")
+
+    assert transform.evaluate_listing_eligibility(soup, "1967 Porsche 911S Coupe") == (True, None)
+
+def test_evaluate_listing_eligibility_does_not_reject_empty_category():
+    soup = BeautifulSoup(
+        """
+        <html>
+            <body>
+                <a class="group-link" href="/category/">
+                    <strong class="group-title-label">Category</strong>
+                </a>
+            </body>
+        </html>
+        """,
+        "html.parser",
+    )
 
     assert transform.evaluate_listing_eligibility(soup, "1967 Porsche 911S Coupe") == (True, None)
 


### PR DESCRIPTION
## Summary

- Allow missing or empty BaT `Model` group labels to transform as `model = NULL`.
- Keep `Make` required by raising when the `Make` group is missing or empty.
- Make `listings.model` nullable in the schema and add focused transform/load/schema tests.

## Root Cause

`extract_group_value` raised whenever a requested group was missing or empty, and `parse_model` directly indexed into that result. Valid listings without a model label therefore failed transform before they could be loaded.

## Validation

- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_transform.py` → 81 passed
- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_load.py` → 4 passed
- `.venv\Scripts\python.exe -m pytest -q tests\integration\test_postgres_schema.py` → 1 skipped, Docker daemon unavailable
- `.venv\Scripts\python.exe -m pytest -q` → 145 passed, 7 skipped

Closes #78