### PR TITLE
[codex] Log ingest-discovered filter rejections

### DIFF
--- a/app/sources/bat/cli.py
+++ b/app/sources/bat/cli.py
@@ -113,6 +113,11 @@ def ingest_discovered_listings(batch_size=None):
             row.get("source_location"),
         )
         if not eligible:
+            logger.info(
+                "BAT ingest-discovered listing rejected for listing_id=%s stage=stage_1 reason=%s",
+                listing_id,
+                reason,
+            )
             mark_discovered_listing_handled_ineligible(listing_id, reason)
             summary.stage_1_rejected += 1
             continue
@@ -132,6 +137,11 @@ def ingest_discovered_listings(batch_size=None):
 
         eligible, reason = evaluate_listing_eligibility(soup, listing_title)
         if not eligible:
+            logger.info(
+                "BAT ingest-discovered listing rejected for listing_id=%s stage=stage_2 reason=%s",
+                listing_id,
+                reason,
+            )
             mark_discovered_listing_handled_ineligible(listing_id, reason)
             summary.stage_2_rejected += 1
             continue

--- a/tests/unit/bat/test_cli.py
+++ b/tests/unit/bat/test_cli.py
@@ -290,7 +290,7 @@ def test_transform_discovered_listings_returns_zeroed_summary_for_empty_batch(mo
     assert summary == cli.BatchTransformSummary()
 
 
-def test_ingest_discovered_listings_marks_stage_1_reject_without_scrape(mocker):
+def test_ingest_discovered_listings_marks_stage_1_reject_without_scrape(mocker, caplog):
     mocker.patch(
         "app.sources.bat.cli.load_pending_discovered_listings",
         return_value=[
@@ -309,10 +309,15 @@ def test_ingest_discovered_listings_marks_stage_1_reject_without_scrape(mocker):
     mark_ineligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_ineligible")
     fetch_listing_html = mocker.patch("app.sources.bat.cli.fetch_listing_html")
 
+    caplog.set_level(logging.INFO)
     summary = cli.ingest_discovered_listings()
 
     mark_ineligible.assert_called_once_with("stage-1-reject", "year before 1946")
     fetch_listing_html.assert_not_called()
+    assert (
+        "BAT ingest-discovered listing rejected for listing_id=stage-1-reject "
+        "stage=stage_1 reason=year before 1946"
+    ) in caplog.text
     assert summary == cli.BatchIngestSummary(
         selected=1,
         stage_1_rejected=1,
@@ -353,7 +358,7 @@ def test_ingest_discovered_listings_records_scrape_failure_without_marking_row(m
     )
 
 
-def test_ingest_discovered_listings_marks_stage_2_reject_without_saving_html(mocker):
+def test_ingest_discovered_listings_marks_stage_2_reject_without_saving_html(mocker, caplog):
     mocker.patch(
         "app.sources.bat.cli.load_pending_discovered_listings",
         return_value=[
@@ -380,10 +385,15 @@ def test_ingest_discovered_listings_marks_stage_2_reject_without_saving_html(moc
     mark_ineligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_ineligible")
     save_listing_html = mocker.patch("app.sources.bat.cli.save_listing_html")
 
+    caplog.set_level(logging.INFO)
     summary = cli.ingest_discovered_listings()
 
     mark_ineligible.assert_called_once_with("stage-2-reject", "excluded category: projects")
     save_listing_html.assert_not_called()
+    assert (
+        "BAT ingest-discovered listing rejected for listing_id=stage-2-reject "
+        "stage=stage_2 reason=excluded category: projects"
+    ) in caplog.text
     assert summary == cli.BatchIngestSummary(
         selected=1,
         scrape_attempted=1,


### PR DESCRIPTION
## Summary

- Log stage 1 `ingest-discovered` eligibility rejections with `listing_id`, `stage=stage_1`, and `reason`.
- Log stage 2 `ingest-discovered` eligibility rejections with `listing_id`, `stage=stage_2`, and `reason`.
- Extend unit coverage for both rejection log paths while preserving DB handling and summary assertions.

## Root Cause

Filtered `ingest-discovered` rows were marked ineligible in the database and reflected in summary counts, but the rejection stage and reason were not visible in logs.

## Validation

- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_cli.py` → 27 passed
- `.venv\Scripts\python.exe -m pytest -q` → 152 passed

Closes #79