### PR TITLE
[codex] Parse BAT years from listing IDs

### DIFF
--- a/app/sources/bat/cli.py
+++ b/app/sources/bat/cli.py
@@ -17,8 +17,6 @@ from app.sources.bat.ingest import fetch_listing_html, save_listing_html
 from app.sources.bat.load import load_listing
 from app.sources.bat.transform import (
     evaluate_listing_eligibility,
-    extract_listing_title,
-    get_product_json_ld,
     load_pending_raw_listing_html,
     transform_listing_html,
 )
@@ -109,7 +107,7 @@ def ingest_discovered_listings(batch_size=None):
         summary.selected += 1
         listing_id = row["source_listing_id"]
         eligible, reason = evaluate_discovery_eligibility(
-            row.get("title"),
+            listing_id,
             row.get("source_location"),
         )
         if not eligible:
@@ -131,11 +129,7 @@ def ingest_discovered_listings(batch_size=None):
             continue
 
         soup = BeautifulSoup(html, "html.parser")
-        listing_title = row.get("title")
-        if not listing_title:
-            listing_title = extract_listing_title(soup, get_product_json_ld(soup))
-
-        eligible, reason = evaluate_listing_eligibility(soup, listing_title)
+        eligible, reason = evaluate_listing_eligibility(soup, listing_id)
         if not eligible:
             logger.info(
                 "BAT ingest-discovered listing rejected for listing_id=%s stage=stage_2 reason=%s",

--- a/app/sources/bat/discovery.py
+++ b/app/sources/bat/discovery.py
@@ -287,11 +287,10 @@ def build_discovered_listing_params(candidate):
     }
 
 
-def evaluate_discovery_eligibility(title, source_location):
-    normalized_title = (title or "").strip()
-    year = _parse_title_year(normalized_title)
+def evaluate_discovery_eligibility(listing_id, source_location):
+    year = _parse_listing_id_year(listing_id)
     if year is None:
-        return False, "title year missing"
+        return False, "listing ID year missing"
     if year < DISCOVERY_MIN_YEAR:
         return False, "year before 1946"
     if source_location != DISCOVERY_ALLOWED_SOURCE_LOCATION:
@@ -316,8 +315,8 @@ def _normalize_scrape_date(value):
     raise TypeError("scrape_date must be a date or ISO date string")
 
 
-def _parse_title_year(title):
-    match = re.match(r"(\d{4})\b", title)
+def _parse_listing_id_year(listing_id):
+    match = re.match(r"^(\d{4})(?:-|$)", listing_id or "")
     if not match:
         return None
     return int(match.group(1))

--- a/app/sources/bat/transform.py
+++ b/app/sources/bat/transform.py
@@ -111,11 +111,10 @@ def transform_listing_html(listing_id):
     html = load_listing_html(listing_id)
     soup = BeautifulSoup(html, "html.parser")
     product_data = get_product_json_ld(soup)
-    listing_title = extract_listing_title(soup, product_data)
     listing_details = get_listing_details(soup)
 
     # transformed entries
-    year = parse_year(listing_title)
+    year = parse_listing_id_year(listing_id)
     make = parse_make(soup)
     model = parse_model(soup)
     mileage = parse_mileage(find_detail_value(listing_details, r"\bmiles?\b|\btmu\b|\bunknown\b", "Mileage"))
@@ -145,11 +144,11 @@ def transform_listing_html(listing_id):
     return transformed_data
 
 
-def evaluate_listing_eligibility(soup, listing_title):
+def evaluate_listing_eligibility(soup, listing_id):
     try:
-        year = parse_year(listing_title)
+        year = parse_listing_id_year(listing_id)
     except ValueError:
-        return False, "title year missing"
+        return False, "listing ID year missing"
 
     if year < BAT_MIN_YEAR:
         return False, "year before 1946"
@@ -201,10 +200,10 @@ def _strip_listing_prefix(title):
         raise ValueError("Could not parse listing title")
     return match.group(1).strip()
 
-def parse_year(title):
-    match = re.search(r"\b(\d{4})\b", title)
+def parse_listing_id_year(listing_id):
+    match = re.match(r"^(\d{4})(?:-|$)", listing_id or "")
     if not match:
-        raise ValueError("Could not parse year from listing title")
+        raise ValueError("Could not parse year from listing ID")
     return int(match.group(1))
 
 def parse_model(soup):

--- a/tests/integration/bat/test_transform_discovered_integration.py
+++ b/tests/integration/bat/test_transform_discovered_integration.py
@@ -18,7 +18,7 @@ VALID_RAW_HTML = """
         {
             "@context": "http://schema.org",
             "@type": "Product",
-            "name": "2004 BMW E46 M3",
+            "name": "BMW E46 M3",
             "offers": {
                 "@type": "Offer",
                 "priceCurrency": "USD",
@@ -107,11 +107,11 @@ def test_transform_discovered_processes_successes_retains_failures_and_respects_
         )
 
         assert _raw_processed_states(database_url) == [
-            ("first-success", True),
-            ("second-success", False),
+            ("2004-first-success", True),
+            ("2005-second-success", False),
             ("transform-fail", False),
         ]
-        assert _listing_ids(database_url) == ["first-success"]
+        assert _listing_ids(database_url) == ["2004-first-success"]
 
         second_summary = cli.transform_discovered_listings()
         assert second_summary == cli.BatchTransformSummary(
@@ -122,11 +122,11 @@ def test_transform_discovered_processes_successes_retains_failures_and_respects_
         )
 
         assert _raw_processed_states(database_url) == [
-            ("first-success", True),
-            ("second-success", True),
+            ("2004-first-success", True),
+            ("2005-second-success", True),
             ("transform-fail", False),
         ]
-        assert _listing_ids(database_url) == ["first-success", "second-success"]
+        assert _listing_ids(database_url) == ["2004-first-success", "2005-second-success"]
     finally:
         subprocess.run(["docker", "rm", "-f", container_name], capture_output=True, text=True)
 
@@ -148,8 +148,8 @@ def _insert_raw_listing_rows(database_url):
                     (
                         10,
                         'bringatrailer',
-                        'first-success',
-                        'https://bringatrailer.com/listing/first-success/',
+                        '2004-first-success',
+                        'https://bringatrailer.com/listing/2004-first-success/',
                         %s,
                         TIMESTAMPTZ '2026-04-20 08:00:00+00',
                         FALSE
@@ -166,8 +166,8 @@ def _insert_raw_listing_rows(database_url):
                     (
                         30,
                         'bringatrailer',
-                        'second-success',
-                        'https://bringatrailer.com/listing/second-success/',
+                        '2005-second-success',
+                        'https://bringatrailer.com/listing/2005-second-success/',
                         %s,
                         TIMESTAMPTZ '2026-04-20 09:00:00+00',
                         FALSE

--- a/tests/integration/bat/test_transform_integration.py
+++ b/tests/integration/bat/test_transform_integration.py
@@ -19,7 +19,7 @@ RAW_LISTING_HTML = """
         {
             "@context": "http://schema.org",
             "@type": "Product",
-            "name": "2004 BMW E46 M3",
+            "name": "BMW E46 M3",
             "offers": {
                 "@type": "Offer",
                 "priceCurrency": "USD",

--- a/tests/unit/bat/test_cli.py
+++ b/tests/unit/bat/test_cli.py
@@ -302,7 +302,7 @@ def test_ingest_discovered_listings_marks_stage_1_reject_without_scrape(mocker, 
             }
         ],
     )
-    mocker.patch(
+    evaluate_discovery_eligibility = mocker.patch(
         "app.sources.bat.cli.evaluate_discovery_eligibility",
         return_value=(False, "year before 1946"),
     )
@@ -312,6 +312,7 @@ def test_ingest_discovered_listings_marks_stage_1_reject_without_scrape(mocker, 
     caplog.set_level(logging.INFO)
     summary = cli.ingest_discovered_listings()
 
+    evaluate_discovery_eligibility.assert_called_once_with("stage-1-reject", "US")
     mark_ineligible.assert_called_once_with("stage-1-reject", "year before 1946")
     fetch_listing_html.assert_not_called()
     assert (
@@ -378,7 +379,7 @@ def test_ingest_discovered_listings_marks_stage_2_reject_without_saving_html(moc
         "app.sources.bat.cli.fetch_listing_html",
         return_value="<html><body>listing</body></html>",
     )
-    mocker.patch(
+    evaluate_listing_eligibility = mocker.patch(
         "app.sources.bat.cli.evaluate_listing_eligibility",
         return_value=(False, "excluded category: projects"),
     )
@@ -388,6 +389,9 @@ def test_ingest_discovered_listings_marks_stage_2_reject_without_saving_html(moc
     caplog.set_level(logging.INFO)
     summary = cli.ingest_discovered_listings()
 
+    evaluate_listing_eligibility.assert_called_once()
+    _, listing_id = evaluate_listing_eligibility.call_args.args
+    assert listing_id == "stage-2-reject"
     mark_ineligible.assert_called_once_with("stage-2-reject", "excluded category: projects")
     save_listing_html.assert_not_called()
     assert (
@@ -444,15 +448,15 @@ def test_ingest_discovered_listings_saves_html_and_marks_eligible_for_stage_2_pa
     )
 
 
-def test_ingest_discovered_listings_uses_html_title_fallback_when_discovered_title_missing(mocker):
+def test_ingest_discovered_listings_uses_listing_id_for_stage_2_when_discovered_title_missing(mocker):
     mocker.patch(
         "app.sources.bat.cli.load_pending_discovered_listings",
         return_value=[
             {
-                "source_listing_id": "fallback-title",
+                "source_listing_id": "1967-fallback-title",
                 "title": None,
                 "source_location": "US",
-                "url": "https://bringatrailer.com/listing/fallback-title/",
+                "url": "https://bringatrailer.com/listing/1967-fallback-title/",
             }
         ],
     )
@@ -464,14 +468,6 @@ def test_ingest_discovered_listings_uses_html_title_fallback_when_discovered_tit
         "app.sources.bat.cli.fetch_listing_html",
         return_value="<html><body>listing</body></html>",
     )
-    get_product_json_ld = mocker.patch(
-        "app.sources.bat.cli.get_product_json_ld",
-        return_value={"name": "1967 Porsche 911S Coupe"},
-    )
-    extract_listing_title = mocker.patch(
-        "app.sources.bat.cli.extract_listing_title",
-        return_value="1967 Porsche 911S Coupe",
-    )
     evaluate_listing_eligibility = mocker.patch(
         "app.sources.bat.cli.evaluate_listing_eligibility",
         return_value=(True, None),
@@ -481,11 +477,9 @@ def test_ingest_discovered_listings_uses_html_title_fallback_when_discovered_tit
 
     cli.ingest_discovered_listings()
 
-    get_product_json_ld.assert_called_once()
-    extract_listing_title.assert_called_once()
     evaluate_listing_eligibility.assert_called_once()
-    _, listing_title = evaluate_listing_eligibility.call_args.args
-    assert listing_title == "1967 Porsche 911S Coupe"
+    _, listing_id = evaluate_listing_eligibility.call_args.args
+    assert listing_id == "1967-fallback-title"
 
 
 def test_ingest_discovered_listings_handles_mixed_batch_outcomes(mocker):

--- a/tests/unit/bat/test_discovery.py
+++ b/tests/unit/bat/test_discovery.py
@@ -67,42 +67,49 @@ def test_normalize_completed_auction_candidate_allows_missing_optional_metadata(
     }
 
 
-def test_evaluate_discovery_eligibility_accepts_in_scope_us_car_title():
-    assert discovery.evaluate_discovery_eligibility("2004 BMW M3 Coupe", "US") == (True, None)
+def test_evaluate_discovery_eligibility_accepts_in_scope_us_car_listing_id():
+    assert discovery.evaluate_discovery_eligibility("2004-bmw-m3-coupe", "US") == (True, None)
 
 
 def test_evaluate_discovery_eligibility_rejects_missing_or_unparseable_year():
-    assert discovery.evaluate_discovery_eligibility("BMW M3 Coupe", "US") == (
+    assert discovery.evaluate_discovery_eligibility("bmw-m3-coupe", "US") == (
         False,
-        "title year missing",
+        "listing ID year missing",
     )
 
 
-def test_evaluate_discovery_eligibility_rejects_pre_1946_title():
-    assert discovery.evaluate_discovery_eligibility("1941 Ford Super Deluxe Coupe", "US") == (
+def test_evaluate_discovery_eligibility_rejects_pre_1946_listing_id():
+    assert discovery.evaluate_discovery_eligibility("1941-ford-super-deluxe-coupe", "US") == (
         False,
         "year before 1946",
     )
 
 
 def test_evaluate_discovery_eligibility_rejects_non_us_listing():
-    assert discovery.evaluate_discovery_eligibility("2004 BMW M3 Coupe", "CA") == (
+    assert discovery.evaluate_discovery_eligibility("2004-bmw-m3-coupe", "CA") == (
         False,
         "listing outside US",
     )
 
 
 @pytest.mark.parametrize(
-    "title",
+    "listing_id",
     [
-        "2004 Harley-Davidson Motorcycle",
-        "1967 Porsche 911 Literature Collection",
-        "1989 Polaris ATV",
-        "1967 Ford F-250 Fire Truck",
+        "2004-harley-davidson-motorcycle",
+        "1967-porsche-911-literature-collection",
+        "1989-polaris-atv",
+        "1967-ford-f-250-fire-truck",
     ],
 )
-def test_evaluate_discovery_eligibility_keeps_valid_year_and_location_titles_in_scope(title):
-    assert discovery.evaluate_discovery_eligibility(title, "US") == (True, None)
+def test_evaluate_discovery_eligibility_keeps_valid_year_and_location_listing_ids_in_scope(listing_id):
+    assert discovery.evaluate_discovery_eligibility(listing_id, "US") == (True, None)
+
+
+def test_evaluate_discovery_eligibility_uses_listing_id_when_title_has_no_year():
+    assert discovery.evaluate_discovery_eligibility("2010-am-general-hmmwv-military-5", "US") == (
+        True,
+        None,
+    )
 
 
 def test_discover_completed_auctions_returns_summary_counts_across_pages(mocker):

--- a/tests/unit/bat/test_transform.py
+++ b/tests/unit/bat/test_transform.py
@@ -218,9 +218,8 @@ def test_load_pending_raw_listing_html_requires_database_url(mocker):
 def test_transform_listing_html_logs_success_without_raw_html(mocker, caplog):
     mocker.patch.object(transform, "load_listing_html", return_value="<html>SENSITIVE_RAW_HTML</html>")
     mocker.patch.object(transform, "get_product_json_ld", return_value={"name": "One Owner 2004 BMW M3"})
-    mocker.patch.object(transform, "extract_listing_title", return_value="2004 BMW M3")
     mocker.patch.object(transform, "get_listing_details", return_value=["Chassis: WBSBL93414PN57203"])
-    mocker.patch.object(transform, "parse_year", return_value=2004)
+    mocker.patch.object(transform, "parse_listing_id_year", return_value=2004)
     mocker.patch.object(transform, "parse_make", return_value="BMW")
     mocker.patch.object(transform, "parse_model", return_value="M3")
     mocker.patch.object(transform, "find_detail_value", side_effect=["50,250 Miles", "Chassis: WBSBL93414PN57203", "6-Speed Manual Transmission"])
@@ -232,11 +231,11 @@ def test_transform_listing_html_logs_success_without_raw_html(mocker, caplog):
     mocker.patch.object(transform, "normalize_transmission", return_value="manual")
 
     caplog.set_level(logging.INFO)
-    transformed = transform.transform_listing_html("test-id")
+    transformed = transform.transform_listing_html("2004-test-id")
 
-    assert transformed["listing_id"] == "test-id"
-    assert "Transforming BAT listing HTML for listing_id=test-id" in caplog.text
-    assert "Transformed BAT listing HTML for listing_id=test-id" in caplog.text
+    assert transformed["listing_id"] == "2004-test-id"
+    assert "Transforming BAT listing HTML for listing_id=2004-test-id" in caplog.text
+    assert "Transformed BAT listing HTML for listing_id=2004-test-id" in caplog.text
     assert "SENSITIVE_RAW_HTML" not in caplog.text
 
 def test_transform_listing_html_allows_missing_model(mocker):
@@ -247,7 +246,7 @@ def test_transform_listing_html_allows_missing_model(mocker):
             {
                 "@context": "http://schema.org",
                 "@type": "Product",
-                "name": "One Owner 2004 BMW M3",
+                "name": "One Owner BMW M3",
                 "offers": {
                     "@type": "Offer",
                     "priceCurrency": "USD",
@@ -278,10 +277,11 @@ def test_transform_listing_html_allows_missing_model(mocker):
     """
     mocker.patch.object(transform, "load_listing_html", return_value=html_content)
 
-    transformed = transform.transform_listing_html("missing-model")
+    transformed = transform.transform_listing_html("2004-missing-model")
 
     assert transformed["make"] == "BMW"
     assert transformed["model"] is None
+    assert transformed["year"] == 2004
 
 def test_get_product_json_ld_returns_product_data(tmp_path):
     # create a test HTML file with a valid JSON-LD script tag
@@ -437,16 +437,25 @@ def test_extract_listing_title_not_found():
     }
     with pytest.raises(ValueError, match="Could not parse listing title"):
         transform.extract_listing_title(soup, product_data)
-    
-def test_parse_year_valid_title():
-    title = "2026 Make Model Title"
-    year = transform.parse_year(title)
-    assert year == 2026
 
-def test_parse_year_invalid_title():
-    title = "Make Model Title"
-    with pytest.raises(ValueError, match="Could not parse year from listing title"):
-        transform.parse_year(title)
+def test_parse_listing_id_year_reads_leading_year():
+    assert transform.parse_listing_id_year("2026-make-model") == 2026
+    assert transform.parse_listing_id_year("2026") == 2026
+
+
+@pytest.mark.parametrize(
+    "listing_id",
+    [
+        "make-model-2026",
+        "26-make-model",
+        "20260-make-model",
+        "",
+        None,
+    ],
+)
+def test_parse_listing_id_year_rejects_missing_leading_year(listing_id):
+    with pytest.raises(ValueError, match="Could not parse year from listing ID"):
+        transform.parse_listing_id_year(listing_id)
 
 def test_parse_model_valid():
     html_content = """
@@ -652,16 +661,16 @@ def test_extract_group_value_returns_none_for_empty_group_value():
 def test_evaluate_listing_eligibility_rejects_missing_or_unparseable_year():
     soup = BeautifulSoup("<html></html>", "html.parser")
 
-    assert transform.evaluate_listing_eligibility(soup, "Factory Five Cobra Replica") == (
+    assert transform.evaluate_listing_eligibility(soup, "factory-five-cobra-replica") == (
         False,
-        "title year missing",
+        "listing ID year missing",
     )
 
 
-def test_evaluate_listing_eligibility_rejects_pre_1946_title():
+def test_evaluate_listing_eligibility_rejects_pre_1946_listing_id():
     soup = BeautifulSoup("<html></html>", "html.parser")
 
-    assert transform.evaluate_listing_eligibility(soup, "1941 Ford Super Deluxe Coupe") == (
+    assert transform.evaluate_listing_eligibility(soup, "1941-ford-super-deluxe-coupe") == (
         False,
         "year before 1946",
     )
@@ -682,7 +691,7 @@ def test_evaluate_listing_eligibility_rejects_excluded_category():
         "html.parser",
     )
 
-    assert transform.evaluate_listing_eligibility(soup, "1967 Porsche 911S Coupe") == (
+    assert transform.evaluate_listing_eligibility(soup, "1967-porsche-911s-coupe") == (
         False,
         "excluded category: Parts",
     )
@@ -706,7 +715,7 @@ def test_evaluate_listing_eligibility_rejects_when_any_category_is_excluded():
         "html.parser",
     )
 
-    assert transform.evaluate_listing_eligibility(soup, "1967 Porsche 911S Coupe") == (
+    assert transform.evaluate_listing_eligibility(soup, "1967-porsche-911s-coupe") == (
         False,
         "excluded category: Parts",
     )
@@ -727,7 +736,7 @@ def test_evaluate_listing_eligibility_rejects_projects_via_category():
         "html.parser",
     )
 
-    assert transform.evaluate_listing_eligibility(soup, "1967 Porsche 911 Coupe") == (
+    assert transform.evaluate_listing_eligibility(soup, "1967-porsche-911-coupe") == (
         False,
         "excluded category: Projects",
     )
@@ -748,13 +757,13 @@ def test_evaluate_listing_eligibility_rejects_race_cars_via_category():
         "html.parser",
     )
 
-    assert transform.evaluate_listing_eligibility(soup, "1997 Porsche 911 GT2 Evo") == (
+    assert transform.evaluate_listing_eligibility(soup, "1997-porsche-911-gt2-evo") == (
         False,
         "excluded category: Race Cars",
     )
 
 
-def test_evaluate_listing_eligibility_rejects_replica_when_title_year_missing():
+def test_evaluate_listing_eligibility_rejects_replica_when_listing_id_year_missing():
     soup = BeautifulSoup(
         """
         <html>
@@ -769,16 +778,25 @@ def test_evaluate_listing_eligibility_rejects_replica_when_title_year_missing():
         "html.parser",
     )
 
-    assert transform.evaluate_listing_eligibility(soup, "Shelby Cobra Replica") == (
+    assert transform.evaluate_listing_eligibility(soup, "shelby-cobra-replica") == (
         False,
-        "title year missing",
+        "listing ID year missing",
     )
 
 
 def test_evaluate_listing_eligibility_does_not_reject_missing_category():
     soup = BeautifulSoup("<html><body></body></html>", "html.parser")
 
-    assert transform.evaluate_listing_eligibility(soup, "1967 Porsche 911S Coupe") == (True, None)
+    assert transform.evaluate_listing_eligibility(soup, "1967-porsche-911s-coupe") == (True, None)
+
+
+def test_evaluate_listing_eligibility_uses_listing_id_when_title_has_no_year():
+    soup = BeautifulSoup("<html><body></body></html>", "html.parser")
+
+    assert transform.evaluate_listing_eligibility(soup, "2010-am-general-hmmwv-military-5") == (
+        True,
+        None,
+    )
 
 def test_evaluate_listing_eligibility_does_not_reject_empty_category():
     soup = BeautifulSoup(
@@ -794,7 +812,7 @@ def test_evaluate_listing_eligibility_does_not_reject_empty_category():
         "html.parser",
     )
 
-    assert transform.evaluate_listing_eligibility(soup, "1967 Porsche 911S Coupe") == (True, None)
+    assert transform.evaluate_listing_eligibility(soup, "1967-porsche-911s-coupe") == (True, None)
 
 
 def test_evaluate_listing_eligibility_does_not_reject_non_excluded_category():
@@ -812,7 +830,7 @@ def test_evaluate_listing_eligibility_does_not_reject_non_excluded_category():
         "html.parser",
     )
 
-    assert transform.evaluate_listing_eligibility(soup, "1967 Porsche 911S Coupe") == (True, None)
+    assert transform.evaluate_listing_eligibility(soup, "1967-porsche-911s-coupe") == (True, None)
 
 def test_evaluate_listing_eligibility_allows_multiple_non_excluded_categories():
     soup = BeautifulSoup(
@@ -833,7 +851,7 @@ def test_evaluate_listing_eligibility_allows_multiple_non_excluded_categories():
         "html.parser",
     )
 
-    assert transform.evaluate_listing_eligibility(soup, "1967 Ford F-250") == (True, None)
+    assert transform.evaluate_listing_eligibility(soup, "1967-ford-f-250") == (True, None)
 
 
 def test_evaluate_listing_eligibility_keeps_truck_and_4x4_in_scope():
@@ -851,7 +869,7 @@ def test_evaluate_listing_eligibility_keeps_truck_and_4x4_in_scope():
         "html.parser",
     )
 
-    assert transform.evaluate_listing_eligibility(soup, "1967 Ford F-250 4x4") == (True, None)
+    assert transform.evaluate_listing_eligibility(soup, "1967-ford-f-250-4x4") == (True, None)
     
 def test_get_listing_details_valid():
     html_content = """


### PR DESCRIPTION
## Summary
- parse BAT listing years from `listing_id` instead of listing title
- update discovery and transform eligibility checks to use listing ID year parsing
- adjust CLI and tests so year extraction no longer depends on title text

## Verification
- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_discovery.py`
- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_transform.py`
- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_cli.py`
- `.venv\Scripts\python.exe -m pytest -q tests\integration\bat\test_transform_integration.py`
- `.venv\Scripts\python.exe -m pytest -q tests\integration\bat\test_transform_discovered_integration.py`
- `.venv\Scripts\python.exe -m pytest -q`

Closes #85