### PR TITLE
[codex] Implement Cars and Bids batch discovery

### DIFF
--- a/app/sources/carsandbids/discovery.py
+++ b/app/sources/carsandbids/discovery.py
@@ -1,0 +1,405 @@
+import logging
+import os
+from dataclasses import dataclass
+from datetime import date, datetime
+from urllib.parse import parse_qs, urlparse
+
+import psycopg
+from playwright.sync_api import sync_playwright
+
+
+SOURCE_SITE = "carsandbids"
+PAST_AUCTIONS_URL = "https://carsandbids.com/past-auctions/"
+LISTING_URL_BASE = "https://carsandbids.com/auctions"
+API_AUCTIONS_URL = "https://carsandbids.com/v2/autos/auctions"
+DISCOVERY_PAGE_SIZE = 50
+DISCOVERY_TIMEOUT_SECONDS = 10
+PAGE_LOAD_TIMEOUT_MS = 60_000
+API_RESPONSE_TIMEOUT_MS = 15_000
+logger = logging.getLogger(__name__)
+
+
+UPSERT_DISCOVERED_LISTING_SQL = """
+INSERT INTO discovered_listings (
+    source_site,
+    source_listing_id,
+    url,
+    title,
+    auction_end_date,
+    source_location
+) VALUES (
+    %(source_site)s,
+    %(source_listing_id)s,
+    %(url)s,
+    %(title)s,
+    %(auction_end_date)s,
+    %(source_location)s
+)
+ON CONFLICT (source_site, source_listing_id) DO UPDATE SET
+    url = EXCLUDED.url,
+    title = EXCLUDED.title,
+    auction_end_date = EXCLUDED.auction_end_date,
+    source_location = EXCLUDED.source_location,
+    last_seen_at = NOW()
+RETURNING xmax = 0 AS inserted
+"""
+
+
+@dataclass
+class DiscoverySummary:
+    candidates_inspected: int = 0
+    newly_discovered: int = 0
+    already_discovered_or_updated: int = 0
+    failed: int = 0
+
+
+def capture_initial_completed_auctions_page(headless=True):
+    logger.info("Capturing initial Cars and Bids completed auctions page")
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=headless)
+        try:
+            page = browser.new_page()
+            payload, timestamp, signature = _capture_initial_completed_auctions_page(
+                page
+            )
+        finally:
+            browser.close()
+
+    logger.info("Captured initial Cars and Bids completed auctions page")
+    return payload, timestamp, signature
+
+
+def _capture_initial_completed_auctions_page(page):
+    matched_response = None
+
+    def is_matching_response(response):
+        return _is_matching_completed_auctions_response(response.url)
+
+    def capture_matching_response(response):
+        nonlocal matched_response
+        if matched_response is None and is_matching_response(response):
+            matched_response = response
+
+    page.on("response", capture_matching_response)
+    page.goto(
+        PAST_AUCTIONS_URL,
+        wait_until="domcontentloaded",
+        timeout=PAGE_LOAD_TIMEOUT_MS,
+    )
+    if matched_response is None:
+        try:
+            matched_response = page.wait_for_event(
+                "response",
+                predicate=is_matching_response,
+                timeout=API_RESPONSE_TIMEOUT_MS,
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                "Cars and Bids completed auctions API response not found"
+            ) from exc
+
+    if matched_response is None:
+        raise RuntimeError("Cars and Bids completed auctions API response not found")
+    if not matched_response.ok:
+        raise RuntimeError(
+            "Cars and Bids completed auctions API response failed "
+            f"status={matched_response.status}"
+        )
+    try:
+        payload = matched_response.json()
+    except Exception as exc:
+        raise RuntimeError("Invalid Cars and Bids completed auctions API JSON") from exc
+
+    timestamp, signature = _extract_signed_request_params(matched_response.url)
+    _extract_auctions(payload)
+    return payload, timestamp, signature
+
+
+def fetch_completed_auctions_page(page, offset, timestamp, signature):
+    params = {
+        "limit": DISCOVERY_PAGE_SIZE,
+        "status": "closed",
+        "offset": offset,
+        "timestamp": timestamp,
+        "signature": signature,
+    }
+    logger.info("Fetching Cars and Bids completed auctions offset=%s", offset)
+    response = page.evaluate(
+        """async ({url, params}) => {
+            const requestUrl = new URL(url);
+            for (const [key, value] of Object.entries(params)) {
+                requestUrl.searchParams.set(key, String(value));
+            }
+            const response = await fetch(requestUrl.toString(), {
+                credentials: "include",
+                headers: {"accept": "application/json"},
+            });
+            const text = await response.text();
+            return {
+                ok: response.ok,
+                status: response.status,
+                text,
+            };
+        }""",
+        {"url": API_AUCTIONS_URL, "params": params},
+    )
+    if not response["ok"]:
+        raise RuntimeError(
+            "Cars and Bids completed auctions API response failed "
+            f"offset={offset} status={response['status']} body={response['text']}"
+        )
+    payload = _parse_json_response_text(response["text"], offset)
+    auctions = _extract_auctions(payload)
+    logger.info(
+        "Fetched Cars and Bids completed auctions offset=%s auctions=%s",
+        offset,
+        len(auctions),
+    )
+    return payload
+
+
+def _is_matching_completed_auctions_response(url):
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    return (
+        url.startswith(API_AUCTIONS_URL)
+        and params.get("status") == ["closed"]
+    )
+
+
+def discover_completed_auctions(scrape_date, max_candidates=None, headless=True):
+    if max_candidates is not None and max_candidates <= 0:
+        return DiscoverySummary()
+
+    normalized_scrape_date = _normalize_scrape_date(scrape_date)
+    summary = DiscoverySummary()
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=headless)
+        try:
+            page = browser.new_page()
+            payload, timestamp, signature = _capture_initial_completed_auctions_page(
+                page
+            )
+            offset = DISCOVERY_PAGE_SIZE
+
+            while True:
+                auctions = _extract_auctions(payload)
+                if not auctions:
+                    logger.info(
+                        "Stopping Cars and Bids discovery because no auctions were returned"
+                    )
+                    break
+
+                stop_discovery = False
+                for auction in auctions:
+                    if (
+                        max_candidates is not None
+                        and summary.candidates_inspected >= max_candidates
+                    ):
+                        stop_discovery = True
+                        break
+
+                    candidate = _build_candidate_from_auction(auction, summary)
+                    if candidate is None:
+                        continue
+
+                    summary.candidates_inspected += 1
+                    listing_id = candidate["listing_id"]
+                    auction_end_date = candidate.get("auction_end_date")
+
+                    if not auction_end_date:
+                        summary.failed += 1
+                        logger.error(
+                            "Failed Cars and Bids discovery candidate for listing_id=%s "
+                            "because auction_end_date is missing",
+                            listing_id,
+                        )
+                        continue
+
+                    if date.fromisoformat(auction_end_date) < normalized_scrape_date:
+                        logger.info(
+                            "Stopping Cars and Bids discovery at listing_id=%s "
+                            "because auction_end_date=%s is older than scrape_date=%s",
+                            listing_id,
+                            auction_end_date,
+                            normalized_scrape_date.isoformat(),
+                        )
+                        stop_discovery = True
+                        break
+
+                    try:
+                        if save_discovered_listing(candidate):
+                            summary.newly_discovered += 1
+                        else:
+                            summary.already_discovered_or_updated += 1
+                    except Exception:
+                        summary.failed += 1
+                        logger.error(
+                            "Failed Cars and Bids discovery candidate for listing_id=%s",
+                            listing_id,
+                        )
+
+                if stop_discovery:
+                    break
+
+                if (
+                    max_candidates is not None
+                    and summary.candidates_inspected >= max_candidates
+                ):
+                    break
+
+                payload = fetch_completed_auctions_page(
+                    page,
+                    offset,
+                    timestamp,
+                    signature,
+                )
+                offset += DISCOVERY_PAGE_SIZE
+        finally:
+            browser.close()
+
+    return summary
+
+
+def normalize_completed_auction_candidate(auction):
+    if not isinstance(auction, dict):
+        raise ValueError("Cars and Bids discovery auction must be an object")
+
+    listing_id = auction.get("id")
+    if listing_id in (None, ""):
+        raise ValueError("Cars and Bids discovery auction id is required")
+
+    listing_id = str(listing_id).strip()
+    if not listing_id:
+        raise ValueError("Cars and Bids discovery auction id is required")
+
+    candidate = {
+        "source_site": SOURCE_SITE,
+        "listing_id": listing_id,
+        "source_listing_id": listing_id,
+        "url": f"{LISTING_URL_BASE}/{listing_id}",
+    }
+
+    title = auction.get("title")
+    if title:
+        candidate["title"] = str(title).strip()
+
+    auction_end_date = _parse_auction_end_date(auction.get("auction_end"))
+    if auction_end_date:
+        candidate["auction_end_date"] = auction_end_date
+
+    location = auction.get("location")
+    candidate["source_location"] = _normalize_source_location(location)
+
+    return candidate
+
+
+def build_discovered_listing_params(candidate):
+    return {
+        "source_site": SOURCE_SITE,
+        "source_listing_id": candidate["listing_id"],
+        "url": candidate["url"],
+        "title": candidate.get("title"),
+        "auction_end_date": candidate.get("auction_end_date"),
+        "source_location": candidate.get("source_location"),
+    }
+
+
+def save_discovered_listing(candidate):
+    database_url = _get_database_url()
+    params = build_discovered_listing_params(candidate)
+
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(UPSERT_DISCOVERED_LISTING_SQL, params)
+            inserted, = cur.fetchone()
+            logger.info(
+                "Upserted Cars and Bids discovered listing for listing_id=%s",
+                params["source_listing_id"],
+            )
+            return inserted
+
+
+def _get_database_url():
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL must be set")
+    return database_url
+
+
+def _normalize_scrape_date(value):
+    if isinstance(value, date):
+        return value
+
+    if isinstance(value, str):
+        return date.fromisoformat(value)
+
+    raise TypeError("scrape_date must be a date or ISO date string")
+
+
+def _extract_signed_request_params(url):
+    params = parse_qs(urlparse(url).query)
+    timestamp = _single_query_value(params, "timestamp")
+    signature = _single_query_value(params, "signature")
+    if not timestamp or not signature:
+        raise RuntimeError(
+            "Cars and Bids completed auctions API response missing signed "
+            "request parameters"
+        )
+    return timestamp, signature
+
+
+def _single_query_value(params, key):
+    values = params.get(key)
+    if not values:
+        return None
+    return values[0]
+
+
+def _extract_auctions(payload):
+    auctions = payload.get("auctions")
+    if not isinstance(auctions, list):
+        raise ValueError("Cars and Bids discovery payload auctions must be a list")
+    return auctions
+
+
+def _parse_json_response_text(text, offset):
+    try:
+        import json
+
+        return json.loads(text)
+    except Exception as exc:
+        raise RuntimeError(
+            "Invalid Cars and Bids completed auctions API JSON "
+            f"offset={offset}"
+        ) from exc
+
+
+def _build_candidate_from_auction(auction, summary):
+    try:
+        return normalize_completed_auction_candidate(auction)
+    except Exception:
+        summary.failed += 1
+        auction_id = auction.get("id") if isinstance(auction, dict) else None
+        logger.error(
+            "Failed Cars and Bids discovery auction normalization for id=%s",
+            auction_id,
+        )
+        return None
+
+
+def _parse_auction_end_date(value):
+    if value in (None, ""):
+        return None
+
+    text = str(value).strip()
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    return datetime.fromisoformat(text).date().isoformat()
+
+
+def _normalize_source_location(location):
+    if location and "canada" in str(location).lower():
+        return "CAN"
+    return "USA"

--- a/tests/live/run_live_discovery_capture.py
+++ b/tests/live/run_live_discovery_capture.py
@@ -1,0 +1,111 @@
+import argparse
+import json
+from urllib.parse import parse_qs, urlparse
+
+from playwright.sync_api import TimeoutError, sync_playwright
+
+from app.sources.carsandbids import discovery
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Capture a live Cars and Bids completed-auctions API response."
+    )
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Run Chromium headless. Default is headed for manual Cloudflare/browser checks.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=180,
+        help="Seconds to wait for the signed closed-auctions API response.",
+    )
+    parser.add_argument(
+        "--print-auction",
+        action="store_true",
+        help="Print the first captured auction object.",
+    )
+    args = parser.parse_args()
+
+    payload, response_url = capture_live_response(
+        headless=args.headless,
+        timeout_ms=args.timeout_seconds * 1000,
+    )
+    timestamp, signature = discovery._extract_signed_request_params(response_url)
+    auctions = discovery._extract_auctions(payload)
+
+    print(
+        json.dumps(
+            {
+                "response_url": response_url,
+                "count": payload.get("count"),
+                "total": payload.get("total"),
+                "auctions": len(auctions),
+                "timestamp": timestamp,
+                "signature_length": len(signature),
+            },
+            indent=2,
+        )
+    )
+    if args.print_auction:
+        print(json.dumps(auctions[0] if auctions else None, indent=2))
+
+
+def capture_live_response(headless=False, timeout_ms=180_000):
+    matched_response = None
+
+    def is_matching_response(response):
+        parsed = urlparse(response.url)
+        params = parse_qs(parsed.query)
+        return (
+            response.url.startswith(discovery.API_AUCTIONS_URL)
+            and params.get("status") == ["closed"]
+        )
+
+    def capture_matching_response(response):
+        nonlocal matched_response
+        if matched_response is None and is_matching_response(response):
+            matched_response = response
+
+    print(f"Opening {discovery.PAST_AUCTIONS_URL}")
+    print("If a browser challenge appears, complete it in the opened Chromium window.")
+    print(f"Waiting up to {timeout_ms // 1000} seconds for the closed-auctions API response...")
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=headless)
+        try:
+            page = browser.new_page()
+            page.on("response", capture_matching_response)
+            page.goto(
+                discovery.PAST_AUCTIONS_URL,
+                wait_until="domcontentloaded",
+                timeout=discovery.PAGE_LOAD_TIMEOUT_MS,
+            )
+
+            if matched_response is None:
+                try:
+                    matched_response = page.wait_for_event(
+                        "response",
+                        predicate=is_matching_response,
+                        timeout=timeout_ms,
+                    )
+                except TimeoutError as exc:
+                    raise RuntimeError(
+                        "Timed out waiting for Cars and Bids closed-auctions API response"
+                    ) from exc
+
+            if not matched_response.ok:
+                raise RuntimeError(
+                    "Cars and Bids completed auctions API response failed "
+                    f"status={matched_response.status}"
+                )
+
+            return matched_response.json(), matched_response.url
+        finally:
+            browser.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/live/run_live_discovery_pagination.py
+++ b/tests/live/run_live_discovery_pagination.py
@@ -1,0 +1,206 @@
+import argparse
+import json
+from urllib.parse import parse_qs, urlparse
+
+from playwright.sync_api import TimeoutError, sync_playwright
+
+from app.sources.carsandbids import discovery
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Manually test live Cars and Bids discovery pagination."
+    )
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Run Chromium headless. Default is headed for manual browser checks.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=180,
+        help="Seconds to wait for the initial signed closed-auctions API response.",
+    )
+    parser.add_argument(
+        "--pages",
+        type=int,
+        default=3,
+        help="Total pages to inspect, including the captured first page.",
+    )
+    parser.add_argument(
+        "--print-first-auction",
+        action="store_true",
+        help="Print the first auction object from each page.",
+    )
+    args = parser.parse_args()
+
+    if args.pages <= 0:
+        raise SystemExit("--pages must be positive")
+
+    results = inspect_pagination(
+        pages=args.pages,
+        headless=args.headless,
+        timeout_ms=args.timeout_seconds * 1000,
+        print_first_auction=args.print_first_auction,
+    )
+    print(json.dumps(results, indent=2))
+
+
+def inspect_pagination(pages, headless=False, timeout_ms=180_000, print_first_auction=False):
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=headless)
+        try:
+            page = browser.new_page()
+            first_payload, response_url = capture_first_page(page, timeout_ms)
+            timestamp, signature = discovery._extract_signed_request_params(response_url)
+
+            results = [
+                build_page_result(
+                    page_number=1,
+                    offset=0,
+                    payload=first_payload,
+                    response_url=response_url,
+                    print_first_auction=print_first_auction,
+                )
+            ]
+
+            offset = discovery.DISCOVERY_PAGE_SIZE
+            for page_number in range(2, pages + 1):
+                payload = fetch_followup_page(
+                    page,
+                    offset=offset,
+                    timestamp=timestamp,
+                    signature=signature,
+                )
+                results.append(
+                    build_page_result(
+                        page_number=page_number,
+                        offset=offset,
+                        payload=payload,
+                        response_url=None,
+                        print_first_auction=print_first_auction,
+                    )
+                )
+                offset += discovery.DISCOVERY_PAGE_SIZE
+
+            return {
+                "page_size": discovery.DISCOVERY_PAGE_SIZE,
+                "timestamp": timestamp,
+                "signature_length": len(signature),
+                "pages": results,
+            }
+        finally:
+            browser.close()
+
+
+def capture_first_page(page, timeout_ms):
+    matched_response = None
+
+    def is_matching_response(response):
+        return is_completed_auctions_response(response.url)
+
+    def capture_matching_response(response):
+        nonlocal matched_response
+        if matched_response is None and is_matching_response(response):
+            matched_response = response
+
+    print(f"Opening {discovery.PAST_AUCTIONS_URL}")
+    print("If a browser challenge appears, complete it in the opened Chromium window.")
+    print(f"Waiting up to {timeout_ms // 1000} seconds for page 1...")
+
+    page.on("response", capture_matching_response)
+    page.goto(
+        discovery.PAST_AUCTIONS_URL,
+        wait_until="domcontentloaded",
+        timeout=discovery.PAGE_LOAD_TIMEOUT_MS,
+    )
+
+    if matched_response is None:
+        try:
+            matched_response = page.wait_for_event(
+                "response",
+                predicate=is_matching_response,
+                timeout=timeout_ms,
+            )
+        except TimeoutError as exc:
+            raise RuntimeError(
+                "Timed out waiting for Cars and Bids closed-auctions API response"
+            ) from exc
+
+    if not matched_response.ok:
+        raise RuntimeError(
+            "Cars and Bids completed auctions API response failed "
+            f"status={matched_response.status}"
+        )
+
+    return matched_response.json(), matched_response.url
+
+
+def fetch_followup_page(page, offset, timestamp, signature):
+    print(f"Fetching follow-up page offset={offset} from inside the browser page...")
+    response = page.evaluate(
+        """async ({url, params}) => {
+            const requestUrl = new URL(url);
+            for (const [key, value] of Object.entries(params)) {
+                requestUrl.searchParams.set(key, String(value));
+            }
+            const response = await fetch(requestUrl.toString(), {
+                credentials: "include",
+                headers: {"accept": "application/json"},
+            });
+            const text = await response.text();
+            return {
+                ok: response.ok,
+                status: response.status,
+                text,
+            };
+        }""",
+        {
+            "url": discovery.API_AUCTIONS_URL,
+            "params": {
+                "limit": discovery.DISCOVERY_PAGE_SIZE,
+                "status": "closed",
+                "offset": offset,
+                "timestamp": timestamp,
+                "signature": signature,
+            },
+        },
+    )
+    if not response["ok"]:
+        raise RuntimeError(
+            "Cars and Bids completed auctions API response failed "
+            f"offset={offset} status={response['status']} body={response['text']}"
+        )
+    return json.loads(response["text"])
+
+
+def build_page_result(page_number, offset, payload, response_url, print_first_auction):
+    auctions = discovery._extract_auctions(payload)
+    result = {
+        "page": page_number,
+        "offset": offset,
+        "count": payload.get("count"),
+        "total": payload.get("total"),
+        "auctions": len(auctions),
+        "first_id": auctions[0].get("id") if auctions and isinstance(auctions[0], dict) else None,
+        "last_id": auctions[-1].get("id") if auctions and isinstance(auctions[-1], dict) else None,
+    }
+    if response_url is not None:
+        result["response_url"] = response_url
+    if print_first_auction:
+        result["first_auction"] = auctions[0] if auctions else None
+    return result
+
+
+def is_completed_auctions_response(url):
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    return (
+        url.startswith(discovery.API_AUCTIONS_URL)
+        and params.get("status") == ["closed"]
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/carsandbids/test_discovery.py
+++ b/tests/unit/carsandbids/test_discovery.py
@@ -1,0 +1,754 @@
+import logging
+import json
+from datetime import date
+
+import pytest
+
+from app.sources.carsandbids import discovery
+
+
+def test_normalize_completed_auction_candidate_maps_endpoint_auction():
+    candidate = discovery.normalize_completed_auction_candidate(
+        {
+            "id": "3gNQk4RZ",
+            "title": " 2004 BMW M3 Coupe ",
+            "auction_end": "2026-04-20T18:30:00Z",
+            "location": "Toronto, Canada",
+        }
+    )
+
+    assert candidate == {
+        "source_site": "carsandbids",
+        "listing_id": "3gNQk4RZ",
+        "source_listing_id": "3gNQk4RZ",
+        "url": "https://carsandbids.com/auctions/3gNQk4RZ",
+        "title": "2004 BMW M3 Coupe",
+        "auction_end_date": "2026-04-20",
+        "source_location": "CAN",
+    }
+
+
+def test_normalize_completed_auction_candidate_defaults_non_canada_location_to_usa():
+    candidate = discovery.normalize_completed_auction_candidate(
+        {
+            "id": "3gNQk4RZ",
+            "auction_end": "2026-04-20T18:30:00+00:00",
+            "location": "Los Angeles, CA",
+        }
+    )
+
+    assert candidate["source_location"] == "USA"
+    assert candidate["auction_end_date"] == "2026-04-20"
+
+
+def test_normalize_completed_auction_candidate_requires_id():
+    with pytest.raises(ValueError, match="auction id is required"):
+        discovery.normalize_completed_auction_candidate({"title": "Missing ID"})
+
+    with pytest.raises(ValueError, match="auction id is required"):
+        discovery.normalize_completed_auction_candidate({"id": "   "})
+
+
+def test_normalize_completed_auction_candidate_requires_object():
+    with pytest.raises(ValueError, match="auction must be an object"):
+        discovery.normalize_completed_auction_candidate("not-an-object")
+
+
+def test_extract_auctions_requires_list():
+    assert discovery._extract_auctions({"auctions": []}) == []
+
+    with pytest.raises(ValueError, match="auctions must be a list"):
+        discovery._extract_auctions({"auctions": {"id": "not-a-list"}})
+
+
+def test_capture_initial_completed_auctions_page_captures_signed_response(
+    mocker, caplog
+):
+    payload = {"auctions": [_auction("first-car", "2026-04-20")]}
+    response = FakeResponse(
+        "https://carsandbids.com/v2/autos/auctions?limit=50&status=closed"
+        "&timestamp=opaque-ts&signature=opaque-sig",
+        payload=payload,
+    )
+    page = FakePage([response])
+    playwright = FakePlaywright(page)
+    mocker.patch.object(
+        discovery, "sync_playwright", return_value=FakePlaywrightContext(playwright)
+    )
+
+    caplog.set_level(logging.INFO)
+    captured_payload, timestamp, signature = (
+        discovery.capture_initial_completed_auctions_page()
+    )
+
+    assert captured_payload == payload
+    assert timestamp == "opaque-ts"
+    assert signature == "opaque-sig"
+    assert page.goto_calls == [
+        ("https://carsandbids.com/past-auctions/", "domcontentloaded", 60000)
+    ]
+    assert playwright.chromium.launch_calls == [{"headless": True}]
+    assert "Capturing initial Cars and Bids completed auctions page" in caplog.text
+    assert "Captured initial Cars and Bids completed auctions page" in caplog.text
+
+
+def test_capture_initial_completed_auctions_page_waits_for_late_matching_response(
+    mocker,
+):
+    matching_response = FakeResponse(
+        "https://carsandbids.com/v2/autos/auctions?status=closed"
+        "&timestamp=late-ts&signature=late-sig",
+        payload={"auctions": []},
+    )
+    page = FakePage([], wait_response=matching_response)
+    mocker.patch.object(
+        discovery,
+        "sync_playwright",
+        return_value=FakePlaywrightContext(FakePlaywright(page)),
+    )
+
+    payload, timestamp, signature = discovery.capture_initial_completed_auctions_page()
+
+    assert payload == {"auctions": []}
+    assert timestamp == "late-ts"
+    assert signature == "late-sig"
+    assert page.wait_for_event_calls == [("response", 15000)]
+
+
+def test_capture_initial_completed_auctions_page_raises_when_response_is_absent(
+    mocker,
+):
+    page = FakePage(
+        [
+            FakeResponse(
+                "https://carsandbids.com/v2/autos/auctions?status=active"
+                "&timestamp=ts&signature=sig"
+            )
+        ]
+    )
+    mocker.patch.object(
+        discovery,
+        "sync_playwright",
+        return_value=FakePlaywrightContext(FakePlaywright(page)),
+    )
+
+    with pytest.raises(RuntimeError, match="API response not found"):
+        discovery.capture_initial_completed_auctions_page()
+
+
+def test_capture_initial_completed_auctions_page_raises_when_response_is_not_ok(
+    mocker,
+):
+    response = FakeResponse(
+        "https://carsandbids.com/v2/autos/auctions?status=closed"
+        "&timestamp=ts&signature=sig",
+        ok=False,
+        status=500,
+    )
+    mocker.patch.object(
+        discovery,
+        "sync_playwright",
+        return_value=FakePlaywrightContext(FakePlaywright(FakePage([response]))),
+    )
+
+    with pytest.raises(RuntimeError, match="API response failed status=500"):
+        discovery.capture_initial_completed_auctions_page()
+
+
+def test_capture_initial_completed_auctions_page_raises_for_missing_signature(
+    mocker,
+):
+    response = FakeResponse(
+        "https://carsandbids.com/v2/autos/auctions?status=closed&timestamp=ts",
+        payload={"auctions": []},
+    )
+    mocker.patch.object(
+        discovery,
+        "sync_playwright",
+        return_value=FakePlaywrightContext(FakePlaywright(FakePage([response]))),
+    )
+
+    with pytest.raises(RuntimeError, match="missing signed request parameters"):
+        discovery.capture_initial_completed_auctions_page()
+
+
+def test_capture_initial_completed_auctions_page_raises_for_invalid_json(mocker):
+    response = FakeResponse(
+        "https://carsandbids.com/v2/autos/auctions?status=closed"
+        "&timestamp=ts&signature=sig",
+        json_error=ValueError("invalid"),
+    )
+    mocker.patch.object(
+        discovery,
+        "sync_playwright",
+        return_value=FakePlaywrightContext(FakePlaywright(FakePage([response]))),
+    )
+
+    with pytest.raises(RuntimeError, match="Invalid Cars and Bids"):
+        discovery.capture_initial_completed_auctions_page()
+
+
+def test_fetch_completed_auctions_page_uses_signed_endpoint_params(mocker, caplog):
+    page = FakePage(
+        [],
+        evaluate_responses=[
+            {"ok": True, "status": 200, "text": _json({"auctions": [_auction("next-car", "2026-04-20")]})}
+        ],
+    )
+
+    caplog.set_level(logging.INFO)
+    payload = discovery.fetch_completed_auctions_page(
+        page,
+        50,
+        "opaque-ts",
+        "opaque-sig",
+    )
+
+    assert payload == {"auctions": [_auction("next-car", "2026-04-20")]}
+    assert page.evaluate_calls == [
+        (
+            {
+                "url": "https://carsandbids.com/v2/autos/auctions",
+                "params": {
+                    "limit": 50,
+                    "status": "closed",
+                    "offset": 50,
+                    "timestamp": "opaque-ts",
+                    "signature": "opaque-sig",
+                },
+            }
+        )
+    ]
+    assert "Fetching Cars and Bids completed auctions offset=50" in caplog.text
+    assert "Fetched Cars and Bids completed auctions offset=50 auctions=1" in caplog.text
+
+
+def test_fetch_completed_auctions_page_raises_when_response_is_not_ok():
+    page = FakePage(
+        [],
+        evaluate_responses=[
+            {"ok": False, "status": 403, "text": '{"message":"blocked"}'}
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match='status=403 body=\\{"message":"blocked"\\}'):
+        discovery.fetch_completed_auctions_page(page, 50, "ts", "sig")
+
+
+def test_fetch_completed_auctions_page_validates_auctions_collection():
+    page = FakePage(
+        [],
+        evaluate_responses=[
+            {"ok": True, "status": 200, "text": _json({"auctions": {"id": "not-a-list"}})}
+        ],
+    )
+
+    with pytest.raises(ValueError, match="auctions must be a list"):
+        discovery.fetch_completed_auctions_page(page, 50, "ts", "sig")
+
+
+def test_discover_completed_auctions_processes_initial_page_then_followups(mocker):
+    page = FakePage(
+        [
+            FakeResponse(
+                "https://carsandbids.com/v2/autos/auctions?limit=50&status=closed"
+                "&timestamp=ts&signature=sig",
+                payload={
+                    "auctions": [
+                        _auction("new-car", "2026-04-20"),
+                        _auction("existing-car", "2026-04-20"),
+                    ]
+                },
+            )
+        ],
+        evaluate_responses=[
+            {
+                "ok": True,
+                "status": 200,
+                "text": _json({"auctions": [_auction("broken-save", "2026-04-20")]}),
+            },
+            {"ok": True, "status": 200, "text": _json({"auctions": []})},
+        ],
+    )
+    mocker.patch.object(
+        discovery,
+        "sync_playwright",
+        return_value=FakePlaywrightContext(FakePlaywright(page)),
+    )
+    save_listing = mocker.patch(
+        "app.sources.carsandbids.discovery.save_discovered_listing",
+        side_effect=[True, False, RuntimeError("boom")],
+    )
+
+    summary = discovery.discover_completed_auctions(scrape_date=date(2026, 4, 20))
+
+    assert summary == discovery.DiscoverySummary(
+        candidates_inspected=3,
+        newly_discovered=1,
+        already_discovered_or_updated=1,
+        failed=1,
+    )
+    assert [call["params"]["offset"] for call in page.evaluate_call_args] == [50, 100]
+    assert [call.args[0]["listing_id"] for call in save_listing.call_args_list] == [
+        "new-car",
+        "existing-car",
+        "broken-save",
+    ]
+
+
+def test_discover_completed_auctions_uses_page_fetch_for_followups(mocker):
+    page = FakePage(
+        [
+            FakeResponse(
+                "https://carsandbids.com/v2/autos/auctions?status=closed"
+                "&timestamp=ts&signature=sig",
+                payload={"auctions": [_auction("first-car", "2026-04-20")]},
+            )
+        ],
+        evaluate_responses=[{"ok": True, "status": 200, "text": _json({"auctions": []})}],
+    )
+    mocker.patch.object(
+        discovery,
+        "sync_playwright",
+        return_value=FakePlaywrightContext(FakePlaywright(page)),
+    )
+    mocker.patch(
+        "app.sources.carsandbids.discovery.save_discovered_listing",
+        return_value=True,
+    )
+
+    discovery.discover_completed_auctions(scrape_date="2026-04-20")
+
+    assert page.evaluate_call_args == [
+        {
+            "url": "https://carsandbids.com/v2/autos/auctions",
+            "params": {
+                "limit": 50,
+                "status": "closed",
+                "offset": 50,
+                "timestamp": "ts",
+                "signature": "sig",
+            },
+        }
+    ]
+
+
+def test_discover_completed_auctions_stops_at_cutoff_date(mocker):
+    page = FakePage(
+        [
+            FakeResponse(
+                "https://carsandbids.com/v2/autos/auctions?status=closed"
+                "&timestamp=ts&signature=sig",
+                payload={
+                    "auctions": [
+                        _auction("newest-car", "2026-04-20"),
+                        _auction("same-day-car", "2026-04-20"),
+                        _auction("older-car", "2026-04-19"),
+                    ]
+                },
+            )
+        ]
+    )
+    mocker.patch.object(
+        discovery,
+        "sync_playwright",
+        return_value=FakePlaywrightContext(FakePlaywright(page)),
+    )
+    save_listing = mocker.patch(
+        "app.sources.carsandbids.discovery.save_discovered_listing",
+        return_value=True,
+    )
+
+    summary = discovery.discover_completed_auctions(scrape_date="2026-04-20")
+
+    assert summary == discovery.DiscoverySummary(
+        candidates_inspected=3,
+        newly_discovered=2,
+        already_discovered_or_updated=0,
+        failed=0,
+    )
+    assert [call.args[0]["listing_id"] for call in save_listing.call_args_list] == [
+        "newest-car",
+        "same-day-car",
+    ]
+    assert page.evaluate_call_args == []
+
+
+def test_discover_completed_auctions_stops_at_max_candidates_without_followup(mocker):
+    page = FakePage(
+        [
+            FakeResponse(
+                "https://carsandbids.com/v2/autos/auctions?status=closed"
+                "&timestamp=ts&signature=sig",
+                payload={
+                    "auctions": [
+                        _auction("first-car", "2026-04-20"),
+                        _auction("second-car", "2026-04-20"),
+                        _auction("third-car", "2026-04-20"),
+                    ]
+                },
+            )
+        ]
+    )
+    mocker.patch.object(
+        discovery,
+        "sync_playwright",
+        return_value=FakePlaywrightContext(FakePlaywright(page)),
+    )
+    save_listing = mocker.patch(
+        "app.sources.carsandbids.discovery.save_discovered_listing",
+        return_value=True,
+    )
+
+    summary = discovery.discover_completed_auctions(
+        scrape_date="2026-04-20",
+        max_candidates=2,
+    )
+
+    assert summary == discovery.DiscoverySummary(
+        candidates_inspected=2,
+        newly_discovered=2,
+        already_discovered_or_updated=0,
+        failed=0,
+    )
+    assert [call.args[0]["listing_id"] for call in save_listing.call_args_list] == [
+        "first-car",
+        "second-car",
+    ]
+    assert page.evaluate_call_args == []
+
+
+def test_discover_completed_auctions_stops_when_no_auctions_returned(mocker):
+    page = FakePage(
+        [
+            FakeResponse(
+                "https://carsandbids.com/v2/autos/auctions?status=closed"
+                "&timestamp=ts&signature=sig",
+                payload={"auctions": [_auction("first-car", "2026-04-20")]},
+            )
+        ],
+        evaluate_responses=[{"ok": True, "status": 200, "text": _json({"auctions": []})}],
+    )
+    mocker.patch.object(
+        discovery,
+        "sync_playwright",
+        return_value=FakePlaywrightContext(FakePlaywright(page)),
+    )
+    save_listing = mocker.patch(
+        "app.sources.carsandbids.discovery.save_discovered_listing",
+        return_value=True,
+    )
+
+    summary = discovery.discover_completed_auctions(scrape_date="2026-04-20")
+
+    assert summary == discovery.DiscoverySummary(
+        candidates_inspected=1,
+        newly_discovered=1,
+        already_discovered_or_updated=0,
+        failed=0,
+    )
+    assert [call["params"]["offset"] for call in page.evaluate_call_args] == [50]
+    save_listing.assert_called_once()
+
+
+def test_discover_completed_auctions_counts_malformed_auctions_and_continues(
+    mocker,
+):
+    page = FakePage(
+        [
+            FakeResponse(
+                "https://carsandbids.com/v2/autos/auctions?status=closed"
+                "&timestamp=ts&signature=sig",
+                payload={
+                    "auctions": [
+                        {"title": "Missing ID"},
+                        "not-an-object",
+                        _auction("valid-car", "2026-04-20"),
+                    ]
+                },
+            )
+        ],
+        evaluate_responses=[{"ok": True, "status": 200, "text": _json({"auctions": []})}],
+    )
+    mocker.patch.object(
+        discovery,
+        "sync_playwright",
+        return_value=FakePlaywrightContext(FakePlaywright(page)),
+    )
+    save_listing = mocker.patch(
+        "app.sources.carsandbids.discovery.save_discovered_listing",
+        return_value=True,
+    )
+
+    summary = discovery.discover_completed_auctions(scrape_date="2026-04-20")
+
+    assert summary == discovery.DiscoverySummary(
+        candidates_inspected=1,
+        newly_discovered=1,
+        already_discovered_or_updated=0,
+        failed=2,
+    )
+    save_listing.assert_called_once()
+
+
+def test_discover_completed_auctions_marks_missing_auction_end_date_as_failed(
+    mocker,
+):
+    page = FakePage(
+        [
+            FakeResponse(
+                "https://carsandbids.com/v2/autos/auctions?status=closed"
+                "&timestamp=ts&signature=sig",
+                payload={
+                    "auctions": [
+                        {"id": "missing-date"},
+                        _auction("valid-car", "2026-04-20"),
+                    ]
+                },
+            )
+        ],
+        evaluate_responses=[{"ok": True, "status": 200, "text": _json({"auctions": []})}],
+    )
+    mocker.patch.object(
+        discovery,
+        "sync_playwright",
+        return_value=FakePlaywrightContext(FakePlaywright(page)),
+    )
+    save_listing = mocker.patch(
+        "app.sources.carsandbids.discovery.save_discovered_listing",
+        return_value=True,
+    )
+
+    summary = discovery.discover_completed_auctions(scrape_date="2026-04-20")
+
+    assert summary == discovery.DiscoverySummary(
+        candidates_inspected=2,
+        newly_discovered=1,
+        already_discovered_or_updated=0,
+        failed=1,
+    )
+    save_listing.assert_called_once()
+
+
+def test_discover_completed_auctions_returns_empty_summary_for_non_positive_limit(
+    mocker,
+):
+    sync_playwright = mocker.patch.object(discovery, "sync_playwright")
+
+    assert discovery.discover_completed_auctions(
+        scrape_date="2026-04-20",
+        max_candidates=0,
+    ) == discovery.DiscoverySummary()
+    sync_playwright.assert_not_called()
+
+
+def test_build_discovered_listing_params_maps_candidate_to_schema_columns():
+    params = discovery.build_discovered_listing_params(
+        {
+            "listing_id": "3gNQk4RZ",
+            "url": "https://carsandbids.com/auctions/3gNQk4RZ",
+            "title": "2004 BMW M3 Coupe",
+            "auction_end_date": "2026-04-20",
+            "source_location": "CAN",
+        }
+    )
+
+    assert params == {
+        "source_site": "carsandbids",
+        "source_listing_id": "3gNQk4RZ",
+        "url": "https://carsandbids.com/auctions/3gNQk4RZ",
+        "title": "2004 BMW M3 Coupe",
+        "auction_end_date": "2026-04-20",
+        "source_location": "CAN",
+    }
+
+
+def test_save_discovered_listing_executes_source_generic_upsert(mocker, caplog):
+    calls = {"executions": []}
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            calls["executions"].append((sql, params))
+
+        def fetchone(self):
+            return (True,)
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    mocker.patch.object(discovery.psycopg, "connect", return_value=FakeConnection())
+
+    caplog.set_level(logging.INFO)
+    inserted = discovery.save_discovered_listing(
+        {
+            "listing_id": "3gNQk4RZ",
+            "url": "https://carsandbids.com/auctions/3gNQk4RZ",
+            "title": "2004 BMW M3 Coupe",
+            "auction_end_date": "2026-04-20",
+            "source_location": "USA",
+        }
+    )
+
+    sql, params = calls["executions"][0]
+    assert inserted is True
+    assert "INSERT INTO discovered_listings" in sql
+    assert "ON CONFLICT (source_site, source_listing_id) DO UPDATE" in sql
+    assert "url = EXCLUDED.url" in sql
+    assert "title = EXCLUDED.title" in sql
+    assert "auction_end_date = EXCLUDED.auction_end_date" in sql
+    assert "source_location = EXCLUDED.source_location" in sql
+    assert "last_seen_at = NOW()" in sql
+    assert "eligible" not in sql
+    assert "eligibility_reason" not in sql
+    assert "ingested_at" not in sql
+    assert params == {
+        "source_site": "carsandbids",
+        "source_listing_id": "3gNQk4RZ",
+        "url": "https://carsandbids.com/auctions/3gNQk4RZ",
+        "title": "2004 BMW M3 Coupe",
+        "auction_end_date": "2026-04-20",
+        "source_location": "USA",
+    }
+    assert "Upserted Cars and Bids discovered listing for listing_id=3gNQk4RZ" in caplog.text
+    assert "postgresql://user:pass@localhost/db" not in caplog.text
+
+
+def test_save_discovered_listing_requires_database_url(mocker):
+    mocker.patch.dict("os.environ", {}, clear=True)
+
+    with pytest.raises(RuntimeError, match="DATABASE_URL must be set"):
+        discovery.save_discovered_listing(
+            {
+                "listing_id": "3gNQk4RZ",
+                "url": "https://carsandbids.com/auctions/3gNQk4RZ",
+            }
+        )
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        url="https://carsandbids.com/v2/autos/auctions?status=closed",
+        payload=None,
+        ok=True,
+        status=200,
+        json_error=None,
+    ):
+        self.url = url
+        self.payload = payload or {"auctions": []}
+        self.ok = ok
+        self.status = status
+        self.json_error = json_error
+
+    def json(self):
+        if self.json_error is not None:
+            raise self.json_error
+        return self.payload
+
+
+class FakePage:
+    def __init__(self, responses, wait_response=None, evaluate_responses=None):
+        self.responses = responses
+        self.wait_response = wait_response
+        self.evaluate_responses = evaluate_responses or []
+        self.response_handler = None
+        self.goto_calls = []
+        self.wait_for_event_calls = []
+        self.evaluate_calls = []
+        self.evaluate_call_args = []
+
+    def on(self, event_name, handler):
+        assert event_name == "response"
+        self.response_handler = handler
+
+    def goto(self, url, wait_until, timeout):
+        self.goto_calls.append((url, wait_until, timeout))
+        for response in self.responses:
+            self.response_handler(response)
+
+    def wait_for_event(self, event_name, predicate, timeout):
+        assert event_name == "response"
+        self.wait_for_event_calls.append((event_name, timeout))
+        candidates = self.responses[:]
+        if self.wait_response is not None:
+            candidates.append(self.wait_response)
+        for response in candidates:
+            if predicate(response):
+                return response
+        raise TimeoutError("response not found")
+
+    def evaluate(self, script, arg):
+        assert "fetch" in script
+        self.evaluate_calls.append(arg)
+        self.evaluate_call_args.append(arg)
+        if not self.evaluate_responses:
+            raise AssertionError("No fake evaluate response configured")
+        return self.evaluate_responses.pop(0)
+
+
+class FakeBrowser:
+    def __init__(self, page):
+        self.page = page
+        self.closed = False
+
+    def new_page(self):
+        return self.page
+
+    def close(self):
+        self.closed = True
+
+
+class FakeChromium:
+    def __init__(self, page):
+        self.browser = FakeBrowser(page)
+        self.launch_calls = []
+
+    def launch(self, headless):
+        self.launch_calls.append({"headless": headless})
+        return self.browser
+
+
+class FakePlaywright:
+    def __init__(self, page):
+        self.chromium = FakeChromium(page)
+
+
+class FakePlaywrightContext:
+    def __init__(self, playwright):
+        self.playwright = playwright
+
+    def __enter__(self):
+        return self.playwright
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def _auction(listing_id, auction_end_date, title=None, location="Dallas, TX"):
+    return {
+        "id": listing_id,
+        "title": title or listing_id.replace("-", " ").title(),
+        "auction_end": f"{auction_end_date}T12:00:00+00:00",
+        "location": location,
+    }
+
+
+def _json(value):
+    return json.dumps(value)


### PR DESCRIPTION
## Summary

Implements Cars and Bids completed-auction discovery for issue #93.

- Adds `app/sources/carsandbids/discovery.py` with first-page Playwright capture from `/past-auctions/`, signed pagination, candidate normalization, and `discovered_listings` upsert behavior.
- Uses in-page browser `fetch(...)` for follow-up pages so Cars and Bids same-origin/session state is preserved during pagination.
- Adds focused unit tests for response capture, pagination, stop conditions, malformed auction handling, normalization, and persistence params.
- Adds manual live scripts under `tests/live/` for capture and pagination validation without DB writes.

## Validation

- `.venv\Scripts\python.exe -m pytest -q tests\unit\carsandbids\test_discovery.py` -> 25 passed
- `.venv\Scripts\python.exe -m pytest -q tests\unit` -> 211 passed
- `git diff --check` -> passed

Live pagination was manually validated by the user with scripts moved under `tests/live/`.