### PR TITLE
[codex] Unify BAT listing eligibility filter

### DIFF
--- a/app/db/schema.sql
+++ b/app/db/schema.sql
@@ -51,7 +51,6 @@ CREATE TABLE IF NOT EXISTS discovered_listings (
     url TEXT NOT NULL,
     title TEXT,
     auction_end_date DATE,
-    source_location TEXT,
     eligible BOOLEAN,
     eligibility_reason TEXT,
     discovered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/app/sources/bat/cli.py
+++ b/app/sources/bat/cli.py
@@ -8,7 +8,6 @@ from dotenv import load_dotenv
 
 from app.sources.bat.discovery import (
     discover_completed_auctions,
-    evaluate_discovery_eligibility,
     load_pending_discovered_listings,
     mark_discovered_listing_handled_eligible,
     mark_discovered_listing_handled_ineligible,
@@ -29,10 +28,9 @@ logger = logging.getLogger(__name__)
 @dataclass
 class BatchIngestSummary:
     selected: int = 0
-    stage_1_rejected: int = 0
     scrape_attempted: int = 0
     scrape_failed: int = 0
-    stage_2_rejected: int = 0
+    rejected: int = 0
     raw_html_stored: int = 0
     accepted: int = 0
 
@@ -106,19 +104,6 @@ def ingest_discovered_listings(batch_size=None):
     for row in pending_rows:
         summary.selected += 1
         listing_id = row["source_listing_id"]
-        eligible, reason = evaluate_discovery_eligibility(
-            listing_id,
-            row.get("source_location"),
-        )
-        if not eligible:
-            logger.info(
-                "BAT ingest-discovered listing rejected for listing_id=%s stage=stage_1 reason=%s",
-                listing_id,
-                reason,
-            )
-            mark_discovered_listing_handled_ineligible(listing_id, reason)
-            summary.stage_1_rejected += 1
-            continue
 
         summary.scrape_attempted += 1
         try:
@@ -132,12 +117,12 @@ def ingest_discovered_listings(batch_size=None):
         eligible, reason = evaluate_listing_eligibility(soup, listing_id)
         if not eligible:
             logger.info(
-                "BAT ingest-discovered listing rejected for listing_id=%s stage=stage_2 reason=%s",
+                "BAT ingest-discovered listing rejected for listing_id=%s reason=%s",
                 listing_id,
                 reason,
             )
             mark_discovered_listing_handled_ineligible(listing_id, reason)
-            summary.stage_2_rejected += 1
+            summary.rejected += 1
             continue
 
         save_listing_html(listing_id, html, url=row["url"])
@@ -224,22 +209,20 @@ def main(argv=None):
             )
             summary = ingest_discovered_listings(batch_size=args.batch_size)
             logger.info(
-                "BAT ingest-discovered summary selected=%s stage_1_rejected=%s scrape_attempted=%s scrape_failed=%s stage_2_rejected=%s raw_html_stored=%s accepted=%s",
+                "BAT ingest-discovered summary selected=%s scrape_attempted=%s scrape_failed=%s rejected=%s raw_html_stored=%s accepted=%s",
                 summary.selected,
-                summary.stage_1_rejected,
                 summary.scrape_attempted,
                 summary.scrape_failed,
-                summary.stage_2_rejected,
+                summary.rejected,
                 summary.raw_html_stored,
                 summary.accepted,
             )
             print(
                 "Ingest-discovered summary: "
                 f"selected={summary.selected} "
-                f"stage_1_rejected={summary.stage_1_rejected} "
                 f"scrape_attempted={summary.scrape_attempted} "
                 f"scrape_failed={summary.scrape_failed} "
-                f"stage_2_rejected={summary.stage_2_rejected} "
+                f"rejected={summary.rejected} "
                 f"raw_html_stored={summary.raw_html_stored} "
                 f"accepted={summary.accepted}"
             )

--- a/app/sources/bat/discovery.py
+++ b/app/sources/bat/discovery.py
@@ -17,9 +17,6 @@ DISCOVERY_PER_PAGE = 60
 DISCOVERY_TIMEOUT_SECONDS = 10
 logger = logging.getLogger(__name__)
 
-DISCOVERY_MIN_YEAR = 1946
-DISCOVERY_ALLOWED_SOURCE_LOCATION = "US"
-
 
 UPSERT_DISCOVERED_LISTING_SQL = """
 INSERT INTO discovered_listings (
@@ -27,21 +24,18 @@ INSERT INTO discovered_listings (
     source_listing_id,
     url,
     title,
-    auction_end_date,
-    source_location
+    auction_end_date
 ) VALUES (
     %(source_site)s,
     %(source_listing_id)s,
     %(url)s,
     %(title)s,
-    %(auction_end_date)s,
-    %(source_location)s
+    %(auction_end_date)s
 )
 ON CONFLICT (source_site, source_listing_id) DO UPDATE SET
     url = EXCLUDED.url,
     title = EXCLUDED.title,
     auction_end_date = EXCLUDED.auction_end_date,
-    source_location = EXCLUDED.source_location,
     last_seen_at = NOW()
 RETURNING xmax = 0 AS inserted
 """
@@ -54,7 +48,6 @@ SELECT
     url,
     title,
     auction_end_date,
-    source_location,
     eligible,
     eligibility_reason,
     discovered_at,
@@ -143,10 +136,6 @@ def normalize_completed_auction_candidate(item):
     auction_end_date = _parse_auction_end_date(item.get("timestamp_end"))
     if auction_end_date:
         candidate["auction_end_date"] = auction_end_date
-
-    source_location = item.get("country_code")
-    if source_location:
-        candidate["source_location"] = str(source_location).strip()
 
     return candidate
 
@@ -283,19 +272,7 @@ def build_discovered_listing_params(candidate):
         "url": candidate["url"],
         "title": candidate.get("title"),
         "auction_end_date": candidate.get("auction_end_date"),
-        "source_location": candidate.get("source_location"),
     }
-
-
-def evaluate_discovery_eligibility(listing_id, source_location):
-    year = _parse_listing_id_year(listing_id)
-    if year is None:
-        return False, "listing ID year missing"
-    if year < DISCOVERY_MIN_YEAR:
-        return False, "year before 1946"
-    if source_location != DISCOVERY_ALLOWED_SOURCE_LOCATION:
-        return False, "listing outside US"
-    return True, None
 
 
 def _get_database_url():
@@ -313,13 +290,6 @@ def _normalize_scrape_date(value):
         return date.fromisoformat(value)
 
     raise TypeError("scrape_date must be a date or ISO date string")
-
-
-def _parse_listing_id_year(listing_id):
-    match = re.match(r"^(\d{4})(?:-|$)", listing_id or "")
-    if not match:
-        return None
-    return int(match.group(1))
 
 
 def _build_candidate_from_item(item, summary):

--- a/app/sources/bat/transform.py
+++ b/app/sources/bat/transform.py
@@ -11,6 +11,7 @@ from psycopg.rows import dict_row
 SOURCE_SITE = "bringatrailer"
 logger = logging.getLogger(__name__)
 BAT_MIN_YEAR = 1946
+BAT_ALLOWED_COUNTRY = "USA"
 EXCLUDED_CATEGORY_VALUES = {
     "aircraft",
     "all-terrain vehicles",
@@ -153,6 +154,9 @@ def evaluate_listing_eligibility(soup, listing_id):
     if year < BAT_MIN_YEAR:
         return False, "year before 1946"
 
+    if extract_country(soup) != BAT_ALLOWED_COUNTRY:
+        return False, "listing outside US"
+
     categories = extract_group_value(soup, "Category")
     if categories is None:
         return True, None
@@ -162,6 +166,16 @@ def evaluate_listing_eligibility(soup, listing_id):
             return False, f"excluded category: {category}"
 
     return True, None
+
+def extract_country(soup):
+    country_tag = soup.select_one("span.show-country-name")
+    if country_tag is None:
+        return None
+
+    country = country_tag.get_text(" ", strip=True)
+    if not country:
+        return None
+    return country
 
 def get_product_json_ld(soup):
     for script_tag in soup.find_all("script", attrs={"type": "application/ld+json"}):

--- a/app/sources/carsandbids/discovery.py
+++ b/app/sources/carsandbids/discovery.py
@@ -25,21 +25,18 @@ INSERT INTO discovered_listings (
     source_listing_id,
     url,
     title,
-    auction_end_date,
-    source_location
+    auction_end_date
 ) VALUES (
     %(source_site)s,
     %(source_listing_id)s,
     %(url)s,
     %(title)s,
-    %(auction_end_date)s,
-    %(source_location)s
+    %(auction_end_date)s
 )
 ON CONFLICT (source_site, source_listing_id) DO UPDATE SET
     url = EXCLUDED.url,
     title = EXCLUDED.title,
     auction_end_date = EXCLUDED.auction_end_date,
-    source_location = EXCLUDED.source_location,
     last_seen_at = NOW()
 RETURNING xmax = 0 AS inserted
 """
@@ -289,9 +286,6 @@ def normalize_completed_auction_candidate(auction):
     if auction_end_date:
         candidate["auction_end_date"] = auction_end_date
 
-    location = auction.get("location")
-    candidate["source_location"] = _normalize_source_location(location)
-
     return candidate
 
 
@@ -302,7 +296,6 @@ def build_discovered_listing_params(candidate):
         "url": candidate["url"],
         "title": candidate.get("title"),
         "auction_end_date": candidate.get("auction_end_date"),
-        "source_location": candidate.get("source_location"),
     }
 
 
@@ -398,8 +391,3 @@ def _parse_auction_end_date(value):
         text = f"{text[:-1]}+00:00"
     return datetime.fromisoformat(text).date().isoformat()
 
-
-def _normalize_source_location(location):
-    if location and "canada" in str(location).lower():
-        return "CAN"
-    return "USA"

--- a/tests/integration/bat/test_load_integration.py
+++ b/tests/integration/bat/test_load_integration.py
@@ -235,7 +235,6 @@ def _insert_discovered_listing_rows(database_url):
                     url,
                     title,
                     auction_end_date,
-                    source_location,
                     discovered_at,
                     last_seen_at,
                     ingested_at
@@ -247,7 +246,6 @@ def _insert_discovered_listing_rows(database_url):
                         'https://bringatrailer.com/listing/first-pending/',
                         'First Pending',
                         DATE '2026-03-30',
-                        'USA',
                         TIMESTAMPTZ '2026-04-20 08:00:00+00',
                         TIMESTAMPTZ '2026-04-20 08:00:00+00',
                         NULL
@@ -259,7 +257,6 @@ def _insert_discovered_listing_rows(database_url):
                         'https://bringatrailer.com/listing/second-pending/',
                         'Second Pending',
                         DATE '2026-03-31',
-                        'USA',
                         TIMESTAMPTZ '2026-04-20 08:00:00+00',
                         TIMESTAMPTZ '2026-04-20 08:00:00+00',
                         NULL
@@ -271,7 +268,6 @@ def _insert_discovered_listing_rows(database_url):
                         'https://bringatrailer.com/listing/already-ingested/',
                         'Already Ingested',
                         DATE '2026-03-29',
-                        'USA',
                         TIMESTAMPTZ '2026-04-19 08:00:00+00',
                         TIMESTAMPTZ '2026-04-19 08:00:00+00',
                         TIMESTAMPTZ '2026-04-21 08:00:00+00'
@@ -283,7 +279,6 @@ def _insert_discovered_listing_rows(database_url):
                         'https://carsandbids.com/auctions/other-source',
                         'Other Source',
                         DATE '2026-03-28',
-                        'USA',
                         TIMESTAMPTZ '2026-04-18 08:00:00+00',
                         TIMESTAMPTZ '2026-04-18 08:00:00+00',
                         NULL

--- a/tests/integration/test_postgres_schema.py
+++ b/tests/integration/test_postgres_schema.py
@@ -219,7 +219,6 @@ def test_schema_sql_applies_in_isolated_postgres_container():
                   'url',
                   'title',
                   'auction_end_date',
-                  'source_location',
                   'eligible',
                   'eligibility_reason',
                   'discovered_at',
@@ -238,7 +237,6 @@ def test_schema_sql_applies_in_isolated_postgres_container():
             "ingested_at:timestamp with time zone:YES",
             "last_seen_at:timestamp with time zone:NO",
             "source_listing_id:text:NO",
-            "source_location:text:YES",
             "source_site:text:NO",
             "title:text:YES",
             "url:text:NO",
@@ -274,7 +272,6 @@ def test_schema_sql_applies_in_isolated_postgres_container():
                 RETURNING
                     title,
                     auction_end_date,
-                    source_location,
                     eligible,
                     eligibility_reason,
                     discovered_at,
@@ -284,7 +281,6 @@ def test_schema_sql_applies_in_isolated_postgres_container():
             SELECT
                 title IS NULL,
                 auction_end_date IS NULL,
-                source_location IS NULL,
                 eligible IS NULL,
                 eligibility_reason IS NULL,
                 discovered_at IS NOT NULL,
@@ -293,7 +289,7 @@ def test_schema_sql_applies_in_isolated_postgres_container():
             FROM inserted;
             """,
         )
-        assert discovered_defaults == ["t|t|t|t|t|t|t|t"]
+        assert discovered_defaults == ["t|t|t|t|t|t|t"]
 
         discovered_upsert = _psql(
             container_name,
@@ -310,28 +306,24 @@ def test_schema_sql_applies_in_isolated_postgres_container():
                     source_listing_id,
                     url,
                     title,
-                    auction_end_date,
-                    source_location
+                    auction_end_date
                 ) VALUES (
                     'bringatrailer',
                     'schema-discovery-test',
                     'https://bringatrailer.com/listing/schema-discovery-test-updated/',
                     'Updated title',
-                    '2026-03-30',
-                    'CAN'
+                    '2026-03-30'
                 )
                 ON CONFLICT (source_site, source_listing_id) DO UPDATE SET
                     url = EXCLUDED.url,
                     title = EXCLUDED.title,
                     auction_end_date = EXCLUDED.auction_end_date,
-                    source_location = EXCLUDED.source_location,
                     last_seen_at = NOW()
                 RETURNING
                     id,
                     url,
                     title,
                     auction_end_date,
-                    source_location,
                     discovered_at,
                     last_seen_at,
                     eligible,
@@ -345,7 +337,6 @@ def test_schema_sql_applies_in_isolated_postgres_container():
                 url,
                 title,
                 auction_end_date,
-                source_location,
                 upserted.discovered_at = original.discovered_at,
                 upserted.last_seen_at >= original.discovered_at,
                 eligible IS NULL,
@@ -358,7 +349,7 @@ def test_schema_sql_applies_in_isolated_postgres_container():
         assert discovered_upsert == [
             (
                 "1|https://bringatrailer.com/listing/schema-discovery-test-updated/"
-                "|Updated title|2026-03-30|CAN|t|t|t|t|t"
+                "|Updated title|2026-03-30|t|t|t|t|t"
             )
         ]
     finally:

--- a/tests/unit/bat/test_cli.py
+++ b/tests/unit/bat/test_cli.py
@@ -176,10 +176,9 @@ def test_ingest_discovered_command_dispatches_with_parsed_options(mocker, caplog
         "app.sources.bat.cli.ingest_discovered_listings",
         return_value=cli.BatchIngestSummary(
             selected=3,
-            stage_1_rejected=1,
             scrape_attempted=2,
             scrape_failed=1,
-            stage_2_rejected=0,
+            rejected=1,
             raw_html_stored=1,
             accepted=1,
         ),
@@ -191,13 +190,13 @@ def test_ingest_discovered_command_dispatches_with_parsed_options(mocker, caplog
     ingest_discovered_listings.assert_called_once_with(batch_size=5)
     assert "BAT ingest-discovered command started for batch_size=5" in caplog.text
     assert (
-        "BAT ingest-discovered summary selected=3 stage_1_rejected=1 scrape_attempted=2 "
-        "scrape_failed=1 stage_2_rejected=0 raw_html_stored=1 accepted=1"
+        "BAT ingest-discovered summary selected=3 scrape_attempted=2 "
+        "scrape_failed=1 rejected=1 raw_html_stored=1 accepted=1"
     ) in caplog.text
     assert "BAT ingest-discovered command completed for batch_size=5" in caplog.text
     assert (
-        "Ingest-discovered summary: selected=3 stage_1_rejected=1 scrape_attempted=2 "
-        "scrape_failed=1 stage_2_rejected=0 raw_html_stored=1 accepted=1"
+        "Ingest-discovered summary: selected=3 scrape_attempted=2 "
+        "scrape_failed=1 rejected=1 raw_html_stored=1 accepted=1"
     ) in capsys.readouterr().out
 
 
@@ -290,38 +289,44 @@ def test_transform_discovered_listings_returns_zeroed_summary_for_empty_batch(mo
     assert summary == cli.BatchTransformSummary()
 
 
-def test_ingest_discovered_listings_marks_stage_1_reject_without_scrape(mocker, caplog):
+def test_ingest_discovered_listings_marks_reject_without_saving_html(mocker, caplog):
     mocker.patch(
         "app.sources.bat.cli.load_pending_discovered_listings",
         return_value=[
             {
-                "source_listing_id": "stage-1-reject",
+                "source_listing_id": "rejected",
                 "title": "1940 Ford Coupe",
-                "source_location": "US",
-                "url": "https://bringatrailer.com/listing/stage-1-reject/",
+                "url": "https://bringatrailer.com/listing/rejected/",
             }
         ],
     )
-    evaluate_discovery_eligibility = mocker.patch(
-        "app.sources.bat.cli.evaluate_discovery_eligibility",
+    mocker.patch(
+        "app.sources.bat.cli.fetch_listing_html",
+        return_value="<html><body>listing</body></html>",
+    )
+    evaluate_listing_eligibility = mocker.patch(
+        "app.sources.bat.cli.evaluate_listing_eligibility",
         return_value=(False, "year before 1946"),
     )
     mark_ineligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_ineligible")
-    fetch_listing_html = mocker.patch("app.sources.bat.cli.fetch_listing_html")
+    save_listing_html = mocker.patch("app.sources.bat.cli.save_listing_html")
 
     caplog.set_level(logging.INFO)
     summary = cli.ingest_discovered_listings()
 
-    evaluate_discovery_eligibility.assert_called_once_with("stage-1-reject", "US")
-    mark_ineligible.assert_called_once_with("stage-1-reject", "year before 1946")
-    fetch_listing_html.assert_not_called()
+    evaluate_listing_eligibility.assert_called_once()
+    _, listing_id = evaluate_listing_eligibility.call_args.args
+    assert listing_id == "rejected"
+    mark_ineligible.assert_called_once_with("rejected", "year before 1946")
+    save_listing_html.assert_not_called()
     assert (
-        "BAT ingest-discovered listing rejected for listing_id=stage-1-reject "
-        "stage=stage_1 reason=year before 1946"
+        "BAT ingest-discovered listing rejected for listing_id=rejected "
+        "reason=year before 1946"
     ) in caplog.text
     assert summary == cli.BatchIngestSummary(
         selected=1,
-        stage_1_rejected=1,
+        scrape_attempted=1,
+        rejected=1,
     )
 
 
@@ -332,14 +337,9 @@ def test_ingest_discovered_listings_records_scrape_failure_without_marking_row(m
             {
                 "source_listing_id": "scrape-fail",
                 "title": "1967 Porsche 911S Coupe",
-                "source_location": "US",
                 "url": "https://bringatrailer.com/listing/scrape-fail/",
             }
         ],
-    )
-    mocker.patch(
-        "app.sources.bat.cli.evaluate_discovery_eligibility",
-        return_value=(True, None),
     )
     mocker.patch(
         "app.sources.bat.cli.fetch_listing_html",
@@ -359,21 +359,16 @@ def test_ingest_discovered_listings_records_scrape_failure_without_marking_row(m
     )
 
 
-def test_ingest_discovered_listings_marks_stage_2_reject_without_saving_html(mocker, caplog):
+def test_ingest_discovered_listings_marks_category_reject_without_saving_html(mocker, caplog):
     mocker.patch(
         "app.sources.bat.cli.load_pending_discovered_listings",
         return_value=[
             {
-                "source_listing_id": "stage-2-reject",
+                "source_listing_id": "category-reject",
                 "title": "1967 Porsche 911S Coupe",
-                "source_location": "US",
-                "url": "https://bringatrailer.com/listing/stage-2-reject/",
+                "url": "https://bringatrailer.com/listing/category-reject/",
             }
         ],
-    )
-    mocker.patch(
-        "app.sources.bat.cli.evaluate_discovery_eligibility",
-        return_value=(True, None),
     )
     mocker.patch(
         "app.sources.bat.cli.fetch_listing_html",
@@ -391,35 +386,30 @@ def test_ingest_discovered_listings_marks_stage_2_reject_without_saving_html(moc
 
     evaluate_listing_eligibility.assert_called_once()
     _, listing_id = evaluate_listing_eligibility.call_args.args
-    assert listing_id == "stage-2-reject"
-    mark_ineligible.assert_called_once_with("stage-2-reject", "excluded category: projects")
+    assert listing_id == "category-reject"
+    mark_ineligible.assert_called_once_with("category-reject", "excluded category: projects")
     save_listing_html.assert_not_called()
     assert (
-        "BAT ingest-discovered listing rejected for listing_id=stage-2-reject "
-        "stage=stage_2 reason=excluded category: projects"
+        "BAT ingest-discovered listing rejected for listing_id=category-reject "
+        "reason=excluded category: projects"
     ) in caplog.text
     assert summary == cli.BatchIngestSummary(
         selected=1,
         scrape_attempted=1,
-        stage_2_rejected=1,
+        rejected=1,
     )
 
 
-def test_ingest_discovered_listings_saves_html_and_marks_eligible_for_stage_2_pass(mocker):
+def test_ingest_discovered_listings_saves_html_and_marks_eligible_for_pass(mocker):
     mocker.patch(
         "app.sources.bat.cli.load_pending_discovered_listings",
         return_value=[
             {
                 "source_listing_id": "accepted",
                 "title": "1967 Porsche 911S Coupe",
-                "source_location": "US",
                 "url": "https://bringatrailer.com/listing/accepted/",
             }
         ],
-    )
-    mocker.patch(
-        "app.sources.bat.cli.evaluate_discovery_eligibility",
-        return_value=(True, None),
     )
     mocker.patch(
         "app.sources.bat.cli.fetch_listing_html",
@@ -448,21 +438,16 @@ def test_ingest_discovered_listings_saves_html_and_marks_eligible_for_stage_2_pa
     )
 
 
-def test_ingest_discovered_listings_uses_listing_id_for_stage_2_when_discovered_title_missing(mocker):
+def test_ingest_discovered_listings_uses_listing_id_when_discovered_title_missing(mocker):
     mocker.patch(
         "app.sources.bat.cli.load_pending_discovered_listings",
         return_value=[
             {
                 "source_listing_id": "1967-fallback-title",
                 "title": None,
-                "source_location": "US",
                 "url": "https://bringatrailer.com/listing/1967-fallback-title/",
             }
         ],
-    )
-    mocker.patch(
-        "app.sources.bat.cli.evaluate_discovery_eligibility",
-        return_value=(True, None),
     )
     mocker.patch(
         "app.sources.bat.cli.fetch_listing_html",
@@ -487,51 +472,40 @@ def test_ingest_discovered_listings_handles_mixed_batch_outcomes(mocker):
         "app.sources.bat.cli.load_pending_discovered_listings",
         return_value=[
             {
-                "source_listing_id": "stage-1-reject",
+                "source_listing_id": "year-reject",
                 "title": "1940 Ford Coupe",
-                "source_location": "US",
-                "url": "https://bringatrailer.com/listing/stage-1-reject/",
+                "url": "https://bringatrailer.com/listing/year-reject/",
             },
             {
                 "source_listing_id": "scrape-fail",
                 "title": "1967 Porsche 911S Coupe",
-                "source_location": "US",
                 "url": "https://bringatrailer.com/listing/scrape-fail/",
             },
             {
-                "source_listing_id": "stage-2-reject",
+                "source_listing_id": "category-reject",
                 "title": "1969 Porsche 911E Coupe",
-                "source_location": "US",
-                "url": "https://bringatrailer.com/listing/stage-2-reject/",
+                "url": "https://bringatrailer.com/listing/category-reject/",
             },
             {
                 "source_listing_id": "accepted",
                 "title": "1970 Porsche 911T Coupe",
-                "source_location": "US",
                 "url": "https://bringatrailer.com/listing/accepted/",
             },
         ],
     )
     mocker.patch(
-        "app.sources.bat.cli.evaluate_discovery_eligibility",
-        side_effect=[
-            (False, "year before 1946"),
-            (True, None),
-            (True, None),
-            (True, None),
-        ],
-    )
-    mocker.patch(
         "app.sources.bat.cli.fetch_listing_html",
         side_effect=[
+            "<html><body>year reject</body></html>",
             RuntimeError("network failed"),
-            "<html><body>stage-2 reject</body></html>",
+            "<html><body>category reject</body></html>",
             "<html><body>accepted</body></html>",
         ],
     )
     mocker.patch(
         "app.sources.bat.cli.evaluate_listing_eligibility",
         side_effect=[
+            (False, "year before 1946"),
             (False, "excluded category: projects"),
             (True, None),
         ],
@@ -544,16 +518,15 @@ def test_ingest_discovered_listings_handles_mixed_batch_outcomes(mocker):
 
     assert summary == cli.BatchIngestSummary(
         selected=4,
-        stage_1_rejected=1,
-        scrape_attempted=3,
+        scrape_attempted=4,
         scrape_failed=1,
-        stage_2_rejected=1,
+        rejected=2,
         raw_html_stored=1,
         accepted=1,
     )
     assert mark_ineligible.call_args_list == [
-        mocker.call("stage-1-reject", "year before 1946"),
-        mocker.call("stage-2-reject", "excluded category: projects"),
+        mocker.call("year-reject", "year before 1946"),
+        mocker.call("category-reject", "excluded category: projects"),
     ]
     save_listing_html.assert_called_once_with(
         "accepted",

--- a/tests/unit/bat/test_discovery.py
+++ b/tests/unit/bat/test_discovery.py
@@ -39,7 +39,6 @@ def test_normalize_completed_auction_candidate_maps_endpoint_item():
             "url": "https://bringatrailer.com/listing/test-listing/?utm_source=feed#comments",
             "title": " 2004 BMW M3 Coupe ",
             "timestamp_end": _timestamp("2026-04-20"),
-            "country_code": "USA",
         }
     )
 
@@ -50,7 +49,6 @@ def test_normalize_completed_auction_candidate_maps_endpoint_item():
         "url": "https://bringatrailer.com/listing/test-listing/",
         "title": "2004 BMW M3 Coupe",
         "auction_end_date": "2026-04-20",
-        "source_location": "USA",
     }
 
 
@@ -65,52 +63,6 @@ def test_normalize_completed_auction_candidate_allows_missing_optional_metadata(
         "source_listing_id": "test-listing",
         "url": "https://bringatrailer.com/listing/test-listing/",
     }
-
-
-def test_evaluate_discovery_eligibility_accepts_in_scope_us_car_listing_id():
-    assert discovery.evaluate_discovery_eligibility("2004-bmw-m3-coupe", "US") == (True, None)
-
-
-def test_evaluate_discovery_eligibility_rejects_missing_or_unparseable_year():
-    assert discovery.evaluate_discovery_eligibility("bmw-m3-coupe", "US") == (
-        False,
-        "listing ID year missing",
-    )
-
-
-def test_evaluate_discovery_eligibility_rejects_pre_1946_listing_id():
-    assert discovery.evaluate_discovery_eligibility("1941-ford-super-deluxe-coupe", "US") == (
-        False,
-        "year before 1946",
-    )
-
-
-def test_evaluate_discovery_eligibility_rejects_non_us_listing():
-    assert discovery.evaluate_discovery_eligibility("2004-bmw-m3-coupe", "CA") == (
-        False,
-        "listing outside US",
-    )
-
-
-@pytest.mark.parametrize(
-    "listing_id",
-    [
-        "2004-harley-davidson-motorcycle",
-        "1967-porsche-911-literature-collection",
-        "1989-polaris-atv",
-        "1967-ford-f-250-fire-truck",
-    ],
-)
-def test_evaluate_discovery_eligibility_keeps_valid_year_and_location_listing_ids_in_scope(listing_id):
-    assert discovery.evaluate_discovery_eligibility(listing_id, "US") == (True, None)
-
-
-def test_evaluate_discovery_eligibility_uses_listing_id_when_title_has_no_year():
-    assert discovery.evaluate_discovery_eligibility("2010-am-general-hmmwv-military-5", "US") == (
-        True,
-        None,
-    )
-
 
 def test_discover_completed_auctions_returns_summary_counts_across_pages(mocker):
     fetch_completed_auctions_page = mocker.patch(
@@ -213,7 +165,6 @@ def test_discover_completed_auctions_marks_missing_auction_end_date_as_failed(mo
             "url": "https://bringatrailer.com/listing/in-scope/",
             "title": "In Scope",
             "auction_end_date": "2026-04-20",
-            "source_location": "USA",
         }
     )
 
@@ -320,7 +271,6 @@ def test_build_discovered_listing_params_maps_candidate_to_schema_columns():
         "url": "https://bringatrailer.com/listing/test-listing/",
         "title": "2004 BMW M3 Coupe",
         "auction_end_date": "2026-03-30",
-        "source_location": "USA",
     }
 
 
@@ -338,7 +288,6 @@ def test_build_discovered_listing_params_allows_missing_visible_metadata():
         "url": "https://bringatrailer.com/listing/test-listing/",
         "title": None,
         "auction_end_date": None,
-        "source_location": None,
     }
 
 
@@ -389,7 +338,7 @@ def test_save_discovered_listing_executes_upsert_for_visible_metadata(mocker, ca
     assert "url = EXCLUDED.url" in sql
     assert "title = EXCLUDED.title" in sql
     assert "auction_end_date = EXCLUDED.auction_end_date" in sql
-    assert "source_location = EXCLUDED.source_location" in sql
+    assert "source_location" not in sql
     assert "last_seen_at = NOW()" in sql
     assert "eligible" not in sql
     assert "eligibility_reason" not in sql
@@ -401,7 +350,6 @@ def test_save_discovered_listing_executes_upsert_for_visible_metadata(mocker, ca
         "url": "https://bringatrailer.com/listing/test-listing/",
         "title": "2004 BMW M3 Coupe",
         "auction_end_date": "2026-03-30",
-        "source_location": "USA",
     }
     assert "Upserted BAT discovered listing for listing_id=test-listing" in caplog.text
     assert "postgresql://user:pass@localhost/db" not in caplog.text
@@ -424,7 +372,6 @@ def test_load_pending_discovered_listings_selects_pending_bat_rows_in_stable_ord
             "url": "https://bringatrailer.com/listing/first-listing/",
             "title": "First Listing",
             "auction_end_date": date(2026, 3, 30),
-            "source_location": "USA",
             "eligible": None,
             "eligibility_reason": None,
             "discovered_at": datetime(2026, 4, 20, 8, 0, tzinfo=timezone.utc),
@@ -620,16 +567,14 @@ def _candidate():
         "url": "https://bringatrailer.com/listing/test-listing/",
         "title": "2004 BMW M3 Coupe",
         "auction_end_date": "2026-03-30",
-        "source_location": "USA",
     }
 
 
-def _item(listing_id, auction_end_date, title=None, country_code="USA"):
+def _item(listing_id, auction_end_date, title=None):
     return {
         "url": f"https://bringatrailer.com/listing/{listing_id}/",
         "title": title or listing_id.replace("-", " ").title(),
         "timestamp_end": _timestamp(auction_end_date),
-        "country_code": country_code,
         "pages_total": 999,
     }
 

--- a/tests/unit/bat/test_transform.py
+++ b/tests/unit/bat/test_transform.py
@@ -676,11 +676,39 @@ def test_evaluate_listing_eligibility_rejects_pre_1946_listing_id():
     )
 
 
+def test_evaluate_listing_eligibility_rejects_missing_country():
+    soup = BeautifulSoup("<html><body></body></html>", "html.parser")
+
+    assert transform.evaluate_listing_eligibility(soup, "1967-porsche-911s-coupe") == (
+        False,
+        "listing outside US",
+    )
+
+
+def test_evaluate_listing_eligibility_rejects_non_usa_country():
+    soup = BeautifulSoup(
+        """
+        <html>
+            <body>
+                <span class="show-country-name">CAN</span>
+            </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+    assert transform.evaluate_listing_eligibility(soup, "1967-porsche-911s-coupe") == (
+        False,
+        "listing outside US",
+    )
+
+
 def test_evaluate_listing_eligibility_rejects_excluded_category():
     soup = BeautifulSoup(
         """
         <html>
             <body>
+                <span class="show-country-name">USA</span>
                 <a class="group-link" href="/parts/">
                     <strong class="group-title-label">Category</strong>
                     Parts
@@ -701,6 +729,7 @@ def test_evaluate_listing_eligibility_rejects_when_any_category_is_excluded():
         """
         <html>
             <body>
+                <span class="show-country-name">USA</span>
                 <a class="group-link" href="/convertible/">
                     <strong class="group-title-label">Category</strong>
                     Convertibles
@@ -726,6 +755,7 @@ def test_evaluate_listing_eligibility_rejects_projects_via_category():
         """
         <html>
             <body>
+                <span class="show-country-name">USA</span>
                 <a class="group-link" href="/project/">
                     <strong class="group-title-label">Category</strong>
                     Projects
@@ -747,6 +777,7 @@ def test_evaluate_listing_eligibility_rejects_race_cars_via_category():
         """
         <html>
             <body>
+                <span class="show-country-name">USA</span>
                 <a class="group-link" href="/race-car/">
                     <strong class="group-title-label">Category</strong>
                     Race Cars
@@ -768,6 +799,7 @@ def test_evaluate_listing_eligibility_rejects_replica_when_listing_id_year_missi
         """
         <html>
             <body>
+                <span class="show-country-name">USA</span>
                 <a class="group-link" href="/convertible/">
                     <strong class="group-title-label">Category</strong>
                     Convertibles
@@ -785,13 +817,19 @@ def test_evaluate_listing_eligibility_rejects_replica_when_listing_id_year_missi
 
 
 def test_evaluate_listing_eligibility_does_not_reject_missing_category():
-    soup = BeautifulSoup("<html><body></body></html>", "html.parser")
+    soup = BeautifulSoup(
+        '<html><body><span class="show-country-name">USA</span></body></html>',
+        "html.parser",
+    )
 
     assert transform.evaluate_listing_eligibility(soup, "1967-porsche-911s-coupe") == (True, None)
 
 
 def test_evaluate_listing_eligibility_uses_listing_id_when_title_has_no_year():
-    soup = BeautifulSoup("<html><body></body></html>", "html.parser")
+    soup = BeautifulSoup(
+        '<html><body><span class="show-country-name">USA</span></body></html>',
+        "html.parser",
+    )
 
     assert transform.evaluate_listing_eligibility(soup, "2010-am-general-hmmwv-military-5") == (
         True,
@@ -803,6 +841,7 @@ def test_evaluate_listing_eligibility_does_not_reject_empty_category():
         """
         <html>
             <body>
+                <span class="show-country-name">USA</span>
                 <a class="group-link" href="/category/">
                     <strong class="group-title-label">Category</strong>
                 </a>
@@ -820,6 +859,7 @@ def test_evaluate_listing_eligibility_does_not_reject_non_excluded_category():
         """
         <html>
             <body>
+                <span class="show-country-name">USA</span>
                 <a class="group-link" href="/convertible/">
                     <strong class="group-title-label">Category</strong>
                     Convertibles
@@ -837,6 +877,7 @@ def test_evaluate_listing_eligibility_allows_multiple_non_excluded_categories():
         """
         <html>
             <body>
+                <span class="show-country-name">USA</span>
                 <a class="group-link" href="/convertible/">
                     <strong class="group-title-label">Category</strong>
                     Convertibles
@@ -859,6 +900,7 @@ def test_evaluate_listing_eligibility_keeps_truck_and_4x4_in_scope():
         """
         <html>
             <body>
+                <span class="show-country-name">USA</span>
                 <a class="group-link" href="/truck-4x4/">
                     <strong class="group-title-label">Category</strong>
                     Truck & 4x4

--- a/tests/unit/carsandbids/test_discovery.py
+++ b/tests/unit/carsandbids/test_discovery.py
@@ -13,7 +13,6 @@ def test_normalize_completed_auction_candidate_maps_endpoint_auction():
             "id": "3gNQk4RZ",
             "title": " 2004 BMW M3 Coupe ",
             "auction_end": "2026-04-20T18:30:00Z",
-            "location": "Toronto, Canada",
         }
     )
 
@@ -24,20 +23,17 @@ def test_normalize_completed_auction_candidate_maps_endpoint_auction():
         "url": "https://carsandbids.com/auctions/3gNQk4RZ",
         "title": "2004 BMW M3 Coupe",
         "auction_end_date": "2026-04-20",
-        "source_location": "CAN",
     }
 
 
-def test_normalize_completed_auction_candidate_defaults_non_canada_location_to_usa():
+def test_normalize_completed_auction_candidate_parses_offset_auction_end():
     candidate = discovery.normalize_completed_auction_candidate(
         {
             "id": "3gNQk4RZ",
             "auction_end": "2026-04-20T18:30:00+00:00",
-            "location": "Los Angeles, CA",
         }
     )
 
-    assert candidate["source_location"] == "USA"
     assert candidate["auction_end_date"] == "2026-04-20"
 
 
@@ -549,7 +545,6 @@ def test_build_discovered_listing_params_maps_candidate_to_schema_columns():
             "url": "https://carsandbids.com/auctions/3gNQk4RZ",
             "title": "2004 BMW M3 Coupe",
             "auction_end_date": "2026-04-20",
-            "source_location": "CAN",
         }
     )
 
@@ -559,7 +554,6 @@ def test_build_discovered_listing_params_maps_candidate_to_schema_columns():
         "url": "https://carsandbids.com/auctions/3gNQk4RZ",
         "title": "2004 BMW M3 Coupe",
         "auction_end_date": "2026-04-20",
-        "source_location": "CAN",
     }
 
 
@@ -602,7 +596,6 @@ def test_save_discovered_listing_executes_source_generic_upsert(mocker, caplog):
             "url": "https://carsandbids.com/auctions/3gNQk4RZ",
             "title": "2004 BMW M3 Coupe",
             "auction_end_date": "2026-04-20",
-            "source_location": "USA",
         }
     )
 
@@ -613,7 +606,7 @@ def test_save_discovered_listing_executes_source_generic_upsert(mocker, caplog):
     assert "url = EXCLUDED.url" in sql
     assert "title = EXCLUDED.title" in sql
     assert "auction_end_date = EXCLUDED.auction_end_date" in sql
-    assert "source_location = EXCLUDED.source_location" in sql
+    assert "source_location" not in sql
     assert "last_seen_at = NOW()" in sql
     assert "eligible" not in sql
     assert "eligibility_reason" not in sql
@@ -624,7 +617,6 @@ def test_save_discovered_listing_executes_source_generic_upsert(mocker, caplog):
         "url": "https://carsandbids.com/auctions/3gNQk4RZ",
         "title": "2004 BMW M3 Coupe",
         "auction_end_date": "2026-04-20",
-        "source_location": "USA",
     }
     assert "Upserted Cars and Bids discovered listing for listing_id=3gNQk4RZ" in caplog.text
     assert "postgresql://user:pass@localhost/db" not in caplog.text


### PR DESCRIPTION
## Summary

- Collapse BAT discovered-listing filtering into a single post-scrape eligibility check.
- Remove `source_location` from discovered listing storage and source discovery upserts.
- Filter BAT listings by `span.show-country-name` and accept only `USA`.
- Replace stage-specific ingest summary counters with a single `rejected` count.

## Impact

Non-USA, pre-1946, and excluded-category BAT listings are now rejected through the same listing eligibility path after HTML fetch. Discovery no longer stores source location metadata in the shared `discovered_listings` table.

## Validation

- `.venv\Scripts\python.exe -m pytest -q tests\unit`
- `.venv\Scripts\python.exe -m pytest -q tests\integration` (Docker-backed tests skipped in this environment)