### PR TITLE
[codex] Unify BAT eligibility marker

### DIFF
--- a/app/sources/bat/cli.py
+++ b/app/sources/bat/cli.py
@@ -9,8 +9,7 @@ from dotenv import load_dotenv
 from app.sources.bat.discovery import (
     discover_completed_auctions,
     load_pending_discovered_listings,
-    mark_discovered_listing_handled_eligible,
-    mark_discovered_listing_handled_ineligible,
+    mark_discovered_listing_handled,
 )
 from app.sources.bat.ingest import (
     evaluate_listing_eligibility,
@@ -118,19 +117,18 @@ def ingest_discovered_listings(batch_size=None):
 
         soup = BeautifulSoup(html, "html.parser")
         eligible, reason = evaluate_listing_eligibility(soup, listing_id)
+        mark_discovered_listing_handled(listing_id, eligible, reason)
         if not eligible:
             logger.info(
                 "BAT ingest-discovered listing rejected for listing_id=%s reason=%s",
                 listing_id,
                 reason,
             )
-            mark_discovered_listing_handled_ineligible(listing_id, reason)
             summary.rejected += 1
             continue
 
         save_listing_html(listing_id, html, url=row["url"])
         summary.raw_html_stored += 1
-        mark_discovered_listing_handled_eligible(listing_id)
         summary.accepted += 1
 
     return summary

--- a/app/sources/bat/discovery.py
+++ b/app/sources/bat/discovery.py
@@ -59,20 +59,10 @@ WHERE source_site = %(source_site)s
 ORDER BY discovered_at ASC, id ASC
 """
 
-MARK_DISCOVERED_LISTING_HANDLED_INELIGIBLE_SQL = """
+MARK_DISCOVERED_LISTING_HANDLED_SQL = """
 UPDATE discovered_listings
-SET ingested_at = NOW(),
-    eligible = FALSE,
+SET eligible = %(eligible)s,
     eligibility_reason = %(eligibility_reason)s
-WHERE source_site = %(source_site)s
-  AND source_listing_id = %(source_listing_id)s
-"""
-
-MARK_DISCOVERED_LISTING_HANDLED_ELIGIBLE_SQL = """
-UPDATE discovered_listings
-SET ingested_at = NOW(),
-    eligible = TRUE,
-    eligibility_reason = NULL
 WHERE source_site = %(source_site)s
   AND source_listing_id = %(source_listing_id)s
 """
@@ -240,29 +230,25 @@ def load_pending_discovered_listings(limit=None):
             return cur.fetchall()
 
 
-def mark_discovered_listing_handled_ineligible(listing_id, reason):
+def mark_discovered_listing_handled(listing_id, eligible, reason):
+    if eligible:
+        eligibility_reason = None
+    else:
+        if not reason or not str(reason).strip():
+            raise ValueError("reason is required when eligible is false")
+        eligibility_reason = reason
+
     database_url = _get_database_url()
     params = {
         "source_site": SOURCE_SITE,
         "source_listing_id": listing_id,
-        "eligibility_reason": reason,
+        "eligible": eligible,
+        "eligibility_reason": eligibility_reason,
     }
 
     with psycopg.connect(database_url) as conn:
         with conn.cursor() as cur:
-            cur.execute(MARK_DISCOVERED_LISTING_HANDLED_INELIGIBLE_SQL, params)
-
-
-def mark_discovered_listing_handled_eligible(listing_id):
-    database_url = _get_database_url()
-    params = {
-        "source_site": SOURCE_SITE,
-        "source_listing_id": listing_id,
-    }
-
-    with psycopg.connect(database_url) as conn:
-        with conn.cursor() as cur:
-            cur.execute(MARK_DISCOVERED_LISTING_HANDLED_ELIGIBLE_SQL, params)
+            cur.execute(MARK_DISCOVERED_LISTING_HANDLED_SQL, params)
 
 
 def build_discovered_listing_params(candidate):

--- a/tests/integration/bat/test_load_integration.py
+++ b/tests/integration/bat/test_load_integration.py
@@ -176,17 +176,18 @@ def test_discovery_helpers_select_pending_rows_and_persist_handled_state(monkeyp
         limited_rows = discovery.load_pending_discovered_listings(limit=1)
         limited_ids = [row["source_listing_id"] for row in limited_rows]
 
-        discovery.mark_discovered_listing_handled_ineligible(
+        discovery.mark_discovered_listing_handled(
             "first-pending",
+            False,
             "sale_price missing",
         )
-        discovery.mark_discovered_listing_handled_eligible("second-pending")
+        discovery.mark_discovered_listing_handled("second-pending", True, None)
 
         with psycopg.connect(database_url) as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    SELECT source_listing_id, eligible, eligibility_reason, ingested_at IS NOT NULL
+                    SELECT source_listing_id, eligible, eligibility_reason, ingested_at IS NULL
                     FROM discovered_listings
                     WHERE source_site = 'bringatrailer'
                       AND source_listing_id IN ('first-pending', 'second-pending')

--- a/tests/unit/bat/test_cli.py
+++ b/tests/unit/bat/test_cli.py
@@ -308,7 +308,7 @@ def test_ingest_discovered_listings_marks_reject_without_saving_html(mocker, cap
         "app.sources.bat.cli.evaluate_listing_eligibility",
         return_value=(False, "year before 1946"),
     )
-    mark_ineligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_ineligible")
+    mark_handled = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled")
     save_listing_html = mocker.patch("app.sources.bat.cli.save_listing_html")
 
     caplog.set_level(logging.INFO)
@@ -317,7 +317,7 @@ def test_ingest_discovered_listings_marks_reject_without_saving_html(mocker, cap
     evaluate_listing_eligibility.assert_called_once()
     _, listing_id = evaluate_listing_eligibility.call_args.args
     assert listing_id == "rejected"
-    mark_ineligible.assert_called_once_with("rejected", "year before 1946")
+    mark_handled.assert_called_once_with("rejected", False, "year before 1946")
     save_listing_html.assert_not_called()
     assert (
         "BAT ingest-discovered listing rejected for listing_id=rejected "
@@ -345,13 +345,11 @@ def test_ingest_discovered_listings_records_scrape_failure_without_marking_row(m
         "app.sources.bat.cli.fetch_listing_html",
         side_effect=RuntimeError("network failed"),
     )
-    mark_ineligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_ineligible")
-    mark_eligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_eligible")
+    mark_handled = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled")
 
     summary = cli.ingest_discovered_listings()
 
-    mark_ineligible.assert_not_called()
-    mark_eligible.assert_not_called()
+    mark_handled.assert_not_called()
     assert summary == cli.BatchIngestSummary(
         selected=1,
         scrape_attempted=1,
@@ -378,7 +376,7 @@ def test_ingest_discovered_listings_marks_category_reject_without_saving_html(mo
         "app.sources.bat.cli.evaluate_listing_eligibility",
         return_value=(False, "excluded category: projects"),
     )
-    mark_ineligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_ineligible")
+    mark_handled = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled")
     save_listing_html = mocker.patch("app.sources.bat.cli.save_listing_html")
 
     caplog.set_level(logging.INFO)
@@ -387,7 +385,11 @@ def test_ingest_discovered_listings_marks_category_reject_without_saving_html(mo
     evaluate_listing_eligibility.assert_called_once()
     _, listing_id = evaluate_listing_eligibility.call_args.args
     assert listing_id == "category-reject"
-    mark_ineligible.assert_called_once_with("category-reject", "excluded category: projects")
+    mark_handled.assert_called_once_with(
+        "category-reject",
+        False,
+        "excluded category: projects",
+    )
     save_listing_html.assert_not_called()
     assert (
         "BAT ingest-discovered listing rejected for listing_id=category-reject "
@@ -420,7 +422,10 @@ def test_ingest_discovered_listings_saves_html_and_marks_eligible_for_pass(mocke
         return_value=(True, None),
     )
     save_listing_html = mocker.patch("app.sources.bat.cli.save_listing_html")
-    mark_eligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_eligible")
+    mark_handled = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled")
+    calls = mocker.Mock()
+    calls.attach_mock(save_listing_html, "save_listing_html")
+    calls.attach_mock(mark_handled, "mark_handled")
 
     summary = cli.ingest_discovered_listings()
 
@@ -429,7 +434,15 @@ def test_ingest_discovered_listings_saves_html_and_marks_eligible_for_pass(mocke
         "<html><body>listing</body></html>",
         url="https://bringatrailer.com/listing/accepted/",
     )
-    mark_eligible.assert_called_once_with("accepted")
+    mark_handled.assert_called_once_with("accepted", True, None)
+    assert calls.mock_calls == [
+        mocker.call.mark_handled("accepted", True, None),
+        mocker.call.save_listing_html(
+            "accepted",
+            "<html><body>listing</body></html>",
+            url="https://bringatrailer.com/listing/accepted/",
+        ),
+    ]
     assert summary == cli.BatchIngestSummary(
         selected=1,
         scrape_attempted=1,
@@ -458,7 +471,7 @@ def test_ingest_discovered_listings_uses_listing_id_when_discovered_title_missin
         return_value=(True, None),
     )
     mocker.patch("app.sources.bat.cli.save_listing_html")
-    mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_eligible")
+    mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled")
 
     cli.ingest_discovered_listings()
 
@@ -511,8 +524,10 @@ def test_ingest_discovered_listings_handles_mixed_batch_outcomes(mocker):
         ],
     )
     save_listing_html = mocker.patch("app.sources.bat.cli.save_listing_html")
-    mark_ineligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_ineligible")
-    mark_eligible = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled_eligible")
+    mark_handled = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled")
+    calls = mocker.Mock()
+    calls.attach_mock(save_listing_html, "save_listing_html")
+    calls.attach_mock(mark_handled, "mark_handled")
 
     summary = cli.ingest_discovered_listings()
 
@@ -524,16 +539,24 @@ def test_ingest_discovered_listings_handles_mixed_batch_outcomes(mocker):
         raw_html_stored=1,
         accepted=1,
     )
-    assert mark_ineligible.call_args_list == [
-        mocker.call("year-reject", "year before 1946"),
-        mocker.call("category-reject", "excluded category: projects"),
+    assert mark_handled.call_args_list == [
+        mocker.call("year-reject", False, "year before 1946"),
+        mocker.call("category-reject", False, "excluded category: projects"),
+        mocker.call("accepted", True, None),
     ]
     save_listing_html.assert_called_once_with(
         "accepted",
         "<html><body>accepted</body></html>",
         url="https://bringatrailer.com/listing/accepted/",
     )
-    mark_eligible.assert_called_once_with("accepted")
+    assert calls.mock_calls[-2:] == [
+        mocker.call.mark_handled("accepted", True, None),
+        mocker.call.save_listing_html(
+            "accepted",
+            "<html><body>accepted</body></html>",
+            url="https://bringatrailer.com/listing/accepted/",
+        ),
+    ]
 
 
 def test_transform_discovered_listings_handles_mixed_batch_outcomes(mocker, caplog):

--- a/tests/unit/bat/test_discovery.py
+++ b/tests/unit/bat/test_discovery.py
@@ -473,7 +473,7 @@ def test_load_pending_discovered_listings_returns_empty_without_query_for_non_po
     connect.assert_not_called()
 
 
-def test_mark_discovered_listing_handled_ineligible_updates_state(mocker):
+def test_mark_discovered_listing_handled_updates_ineligible_state(mocker):
     calls = {"executions": []}
 
     class FakeCursor:
@@ -502,24 +502,26 @@ def test_mark_discovered_listing_handled_ineligible_updates_state(mocker):
     )
     mocker.patch.object(discovery.psycopg, "connect", return_value=FakeConnection())
 
-    discovery.mark_discovered_listing_handled_ineligible(
+    discovery.mark_discovered_listing_handled(
         "test-listing",
+        False,
         "auction did not meet eligibility rules",
     )
 
     sql, params = calls["executions"][0]
     assert "UPDATE discovered_listings" in sql
-    assert "SET ingested_at = NOW()" in sql
-    assert "eligible = FALSE" in sql
+    assert "ingested_at" not in sql
+    assert "eligible = %(eligible)s" in sql
     assert "eligibility_reason = %(eligibility_reason)s" in sql
     assert params == {
         "source_site": "bringatrailer",
         "source_listing_id": "test-listing",
+        "eligible": False,
         "eligibility_reason": "auction did not meet eligibility rules",
     }
 
 
-def test_mark_discovered_listing_handled_eligible_updates_state(mocker):
+def test_mark_discovered_listing_handled_updates_eligible_state(mocker):
     calls = {"executions": []}
 
     class FakeCursor:
@@ -548,17 +550,36 @@ def test_mark_discovered_listing_handled_eligible_updates_state(mocker):
     )
     mocker.patch.object(discovery.psycopg, "connect", return_value=FakeConnection())
 
-    discovery.mark_discovered_listing_handled_eligible("test-listing")
+    discovery.mark_discovered_listing_handled(
+        "test-listing",
+        True,
+        "ignored reason",
+    )
 
     sql, params = calls["executions"][0]
     assert "UPDATE discovered_listings" in sql
-    assert "SET ingested_at = NOW()" in sql
-    assert "eligible = TRUE" in sql
-    assert "eligibility_reason = NULL" in sql
+    assert "ingested_at" not in sql
+    assert "eligible = %(eligible)s" in sql
+    assert "eligibility_reason = %(eligibility_reason)s" in sql
     assert params == {
         "source_site": "bringatrailer",
         "source_listing_id": "test-listing",
+        "eligible": True,
+        "eligibility_reason": None,
     }
+
+
+def test_mark_discovered_listing_handled_requires_reason_for_ineligible(mocker):
+    connect = mocker.patch.object(discovery.psycopg, "connect")
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+
+    with pytest.raises(ValueError, match="reason is required"):
+        discovery.mark_discovered_listing_handled("test-listing", False, "")
+
+    connect.assert_not_called()
 
 
 def _candidate():


### PR DESCRIPTION
## Summary

- Replace separate BAT discovered-listing eligibility marker functions with one `mark_discovered_listing_handled(listing_id, eligible, reason)` function.
- Use one SQL update path for `eligible` and `eligibility_reason`.
- Stop updating `ingested_at` from the eligibility marker path.
- Update `ingest_discovered_listings` to call the unified marker once after eligibility evaluation, before rejection handling or accepted HTML persistence.

## Validation

- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_discovery.py tests\unit\bat\test_cli.py tests\integration\bat\test_load_integration.py`
  - 46 passed, 2 skipped
- `.venv\Scripts\python.exe -m pytest -q`
  - 213 passed

Closes #98
