### PR TITLE
[codex] Mark discovered listings ingested after raw save

### DIFF
--- a/app/sources/bat/ingest.py
+++ b/app/sources/bat/ingest.py
@@ -51,6 +51,13 @@ ON CONFLICT (source_site, source_listing_id) DO UPDATE SET
     processed = FALSE
 """
 
+MARK_DISCOVERED_LISTING_INGESTED_SQL = """
+UPDATE discovered_listings
+SET ingested_at = NOW()
+WHERE source_site = %(source_site)s
+  AND source_listing_id = %(source_listing_id)s
+"""
+
 
 def fetch_listing_html(id):
     url = f"https://bringatrailer.com/listing/{id}"
@@ -141,6 +148,7 @@ def save_listing_html(listing_id, html, url=None):
     with psycopg.connect(database_url) as conn:
         with conn.cursor() as cur:
             cur.execute(UPSERT_RAW_LISTING_HTML_SQL, params)
+            cur.execute(MARK_DISCOVERED_LISTING_INGESTED_SQL, params)
             logger.info("Saved BAT raw listing HTML for listing_id=%s", listing_id)
 
 

--- a/app/sources/carsandbids/ingest.py
+++ b/app/sources/carsandbids/ingest.py
@@ -33,6 +33,13 @@ ON CONFLICT (source_site, source_listing_id) DO UPDATE SET
     processed = FALSE
 """
 
+MARK_DISCOVERED_LISTING_INGESTED_SQL = """
+UPDATE discovered_listings
+SET ingested_at = NOW()
+WHERE source_site = %(source_site)s
+  AND source_listing_id = %(source_listing_id)s
+"""
+
 
 def build_listing_url(listing_id):
     return f"{LISTING_URL_BASE}/{listing_id}"
@@ -116,6 +123,7 @@ def save_listing_json(listing_id, payload, url=None):
     with psycopg.connect(database_url) as conn:
         with conn.cursor() as cur:
             cur.execute(UPSERT_RAW_LISTING_JSON_SQL, params)
+            cur.execute(MARK_DISCOVERED_LISTING_INGESTED_SQL, params)
             logger.info(
                 "Saved Cars and Bids raw listing JSON for listing_id=%s", listing_id
             )

--- a/tests/integration/carsandbids/test_ingest_integration.py
+++ b/tests/integration/carsandbids/test_ingest_integration.py
@@ -6,18 +6,18 @@ from pathlib import Path
 import psycopg
 import pytest
 
-from app.sources.bat.ingest import save_listing_html
+from app.sources.carsandbids.ingest import save_listing_json
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCHEMA_PATH = REPO_ROOT / "app" / "db" / "schema.sql"
 
 
-def test_save_listing_html_upserts_raw_html_in_postgres_container(monkeypatch):
+def test_save_listing_json_upserts_raw_json_in_postgres_container(monkeypatch):
     if not _docker_daemon_available():
         pytest.skip("Docker daemon is not available")
 
-    container_name = f"auction-ingest-test-{uuid.uuid4().hex}"
+    container_name = f"auction-cnb-ingest-test-{uuid.uuid4().hex}"
     schema_mount = f"{SCHEMA_PATH}:/docker-entrypoint-initdb.d/001-schema.sql:ro"
 
     try:
@@ -52,56 +52,56 @@ def test_save_listing_html_upserts_raw_html_in_postgres_container(monkeypatch):
         monkeypatch.setenv("DATABASE_URL", database_url)
         _insert_discovered_listing(
             database_url,
-            "test-listing",
-            "https://example.test/first",
+            "test-auction",
+            "https://example.test/auctions/test-auction",
         )
 
-        save_listing_html(
-            "test-listing",
-            "<html>First</html>",
-            "https://example.test/first",
+        save_listing_json(
+            "test-auction",
+            {"id": "test-auction", "title": "First"},
+            "https://example.test/auctions/test-auction",
         )
         with psycopg.connect(database_url) as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    UPDATE raw_listing_html
+                    UPDATE raw_listing_json
                     SET processed = TRUE
                     WHERE source_site = %s AND source_listing_id = %s
                     """,
-                    ("bringatrailer", "test-listing"),
+                    ("carsandbids", "test-auction"),
                 )
 
-        save_listing_html(
-            "test-listing",
-            "<html>Second</html>",
-            "https://example.test/second",
+        save_listing_json(
+            "test-auction",
+            {"id": "test-auction", "title": "Second"},
+            "https://example.test/auctions/test-auction-updated",
         )
 
         with psycopg.connect(database_url) as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    SELECT COUNT(*), MAX(url), MAX(raw_html), bool_or(processed)
-                    FROM raw_listing_html
+                    SELECT COUNT(*), MAX(url), MAX(raw_json->>'title'), bool_or(processed)
+                    FROM raw_listing_json
                     WHERE source_site = %s AND source_listing_id = %s
                     """,
-                    ("bringatrailer", "test-listing"),
+                    ("carsandbids", "test-auction"),
                 )
-                row_count, url, raw_html, processed = cur.fetchone()
+                row_count, url, title, processed = cur.fetchone()
                 cur.execute(
                     """
                     SELECT ingested_at IS NOT NULL, eligible, eligibility_reason
                     FROM discovered_listings
                     WHERE source_site = %s AND source_listing_id = %s
                     """,
-                    ("bringatrailer", "test-listing"),
+                    ("carsandbids", "test-auction"),
                 )
                 discovered_ingested, eligible, eligibility_reason = cur.fetchone()
 
         assert row_count == 1
-        assert url == "https://example.test/second"
-        assert raw_html == "<html>Second</html>"
+        assert url == "https://example.test/auctions/test-auction-updated"
+        assert title == "Second"
         assert processed is False
         assert discovered_ingested is True
         assert eligible is None
@@ -125,7 +125,7 @@ def _insert_discovered_listing(database_url, listing_id, url):
                     %s
                 )
                 """,
-                ("bringatrailer", listing_id, url),
+                ("carsandbids", listing_id, url),
             )
 
 

--- a/tests/unit/bat/test_ingest.py
+++ b/tests/unit/bat/test_ingest.py
@@ -70,7 +70,7 @@ def test_build_raw_listing_html_params_defaults_bat_url():
 
 
 def test_save_listing_html_executes_upsert_with_expected_conflict_target(mocker, caplog):
-    calls = {}
+    calls = {"execute": []}
 
     class FakeCursor:
         def __enter__(self):
@@ -80,8 +80,7 @@ def test_save_listing_html_executes_upsert_with_expected_conflict_target(mocker,
             return False
 
         def execute(self, sql, params):
-            calls["sql"] = sql
-            calls["params"] = params
+            calls["execute"].append((sql, params))
 
     class FakeConnection:
         def __enter__(self):
@@ -111,14 +110,24 @@ def test_save_listing_html_executes_upsert_with_expected_conflict_target(mocker,
     )
 
     assert calls["database_url"] == "postgresql://user:pass@localhost/db"
-    assert "ON CONFLICT (source_site, source_listing_id) DO UPDATE" in calls["sql"]
-    assert "processed = FALSE" in calls["sql"]
-    assert calls["params"] == {
+    assert len(calls["execute"]) == 2
+    upsert_sql, upsert_params = calls["execute"][0]
+    marker_sql, marker_params = calls["execute"][1]
+    assert "ON CONFLICT (source_site, source_listing_id) DO UPDATE" in upsert_sql
+    assert "processed = FALSE" in upsert_sql
+    assert "UPDATE discovered_listings" in marker_sql
+    assert "SET ingested_at = NOW()" in marker_sql
+    assert "source_site = %(source_site)s" in marker_sql
+    assert "source_listing_id = %(source_listing_id)s" in marker_sql
+    assert "eligible" not in marker_sql
+    assert "eligibility_reason" not in marker_sql
+    assert upsert_params == {
         "source_site": "bringatrailer",
         "source_listing_id": "test-id",
         "url": "https://example.test/listing/test-id",
         "raw_html": "<html>Test</html>",
     }
+    assert marker_params == upsert_params
     assert "Saved BAT raw listing HTML for listing_id=test-id" in caplog.text
     assert "<html>Test</html>" not in caplog.text
     assert "postgresql://user:pass@localhost/db" not in caplog.text

--- a/tests/unit/carsandbids/test_ingest.py
+++ b/tests/unit/carsandbids/test_ingest.py
@@ -110,7 +110,7 @@ def test_build_raw_listing_json_params_defaults_public_listing_url():
 def test_save_listing_json_executes_upsert_with_expected_conflict_target(
     mocker, caplog
 ):
-    calls = {}
+    calls = {"execute": []}
     payload = {"id": "test-auction", "secret": "payload-content"}
 
     class FakeCursor:
@@ -121,8 +121,7 @@ def test_save_listing_json_executes_upsert_with_expected_conflict_target(
             return False
 
         def execute(self, sql, params):
-            calls["sql"] = sql
-            calls["params"] = params
+            calls["execute"].append((sql, params))
 
     class FakeConnection:
         def __enter__(self):
@@ -152,15 +151,25 @@ def test_save_listing_json_executes_upsert_with_expected_conflict_target(
     )
 
     assert calls["database_url"] == "postgresql://user:pass@localhost/db"
-    assert "ON CONFLICT (source_site, source_listing_id) DO UPDATE" in calls["sql"]
-    assert "url = EXCLUDED.url" in calls["sql"]
-    assert "raw_json = EXCLUDED.raw_json" in calls["sql"]
-    assert "processed = FALSE" in calls["sql"]
-    assert calls["params"]["source_site"] == "carsandbids"
-    assert calls["params"]["source_listing_id"] == "test-auction"
-    assert calls["params"]["url"] == "https://example.test/auctions/test-auction"
-    assert isinstance(calls["params"]["raw_json"], Jsonb)
-    assert calls["params"]["raw_json"].obj == payload
+    assert len(calls["execute"]) == 2
+    upsert_sql, upsert_params = calls["execute"][0]
+    marker_sql, marker_params = calls["execute"][1]
+    assert "ON CONFLICT (source_site, source_listing_id) DO UPDATE" in upsert_sql
+    assert "url = EXCLUDED.url" in upsert_sql
+    assert "raw_json = EXCLUDED.raw_json" in upsert_sql
+    assert "processed = FALSE" in upsert_sql
+    assert "UPDATE discovered_listings" in marker_sql
+    assert "SET ingested_at = NOW()" in marker_sql
+    assert "source_site = %(source_site)s" in marker_sql
+    assert "source_listing_id = %(source_listing_id)s" in marker_sql
+    assert "eligible" not in marker_sql
+    assert "eligibility_reason" not in marker_sql
+    assert upsert_params["source_site"] == "carsandbids"
+    assert upsert_params["source_listing_id"] == "test-auction"
+    assert upsert_params["url"] == "https://example.test/auctions/test-auction"
+    assert isinstance(upsert_params["raw_json"], Jsonb)
+    assert upsert_params["raw_json"].obj == payload
+    assert marker_params == upsert_params
     assert (
         "Saved Cars and Bids raw listing JSON for listing_id=test-auction"
         in caplog.text


### PR DESCRIPTION
## Summary
- Mark BAT discovered listings ingested after raw HTML saves.
- Mark Cars and Bids discovered listings ingested after raw JSON saves.
- Add focused unit and Docker-backed integration coverage for the marker update.

## Validation
- .venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_ingest.py tests\unit\carsandbids\test_ingest.py
- .venv\Scripts\python.exe -m pytest -q tests\integration\bat\test_ingest_integration.py tests\integration\carsandbids\test_ingest_integration.py (skipped locally because Docker was unavailable)
- .venv\Scripts\python.exe -m pytest -q

Closes #99