### PR TITLE
[codex] Select BAT pending listings by eligibility

### DIFF
--- a/app/sources/bat/discovery.py
+++ b/app/sources/bat/discovery.py
@@ -55,7 +55,7 @@ SELECT
     ingested_at
 FROM discovered_listings
 WHERE source_site = %(source_site)s
-  AND ingested_at IS NULL
+  AND eligible IS NULL
 ORDER BY discovered_at ASC, id ASC
 """
 

--- a/tests/unit/bat/test_discovery.py
+++ b/tests/unit/bat/test_discovery.py
@@ -417,7 +417,10 @@ def test_load_pending_discovered_listings_selects_pending_bat_rows_in_stable_ord
     assert calls["cursor_kwargs"] == [{"row_factory": discovery.dict_row}]
     assert "FROM discovered_listings" in sql
     assert "WHERE source_site = %(source_site)s" in sql
-    assert "AND ingested_at IS NULL" in sql
+    assert "AND eligible IS NULL" in sql
+    assert "AND ingested_at IS NULL" not in sql
+    assert "eligible = TRUE" not in sql
+    assert "eligible = FALSE" not in sql
     assert "ORDER BY discovered_at ASC, id ASC" in sql
     assert "LIMIT %(limit)s" not in sql
     assert params == {"source_site": "bringatrailer"}


### PR DESCRIPTION
## Summary

- Select pending BAT discovered listings with `eligible IS NULL` instead of `ingested_at IS NULL`.
- Preserve the source-site filter, stable ordering, selected columns, and optional limit behavior.
- Update focused discovery unit assertions for the new eligibility-state semantics.

## Validation

```powershell
.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_discovery.py
```

Result: `19 passed in 0.26s`

Closes #101