### PR TITLE
[codex] Move BAT pipeline orchestration out of CLI

### DIFF
--- a/app/pipeline/__init__.py
+++ b/app/pipeline/__init__.py
@@ -1,0 +1,1 @@
+"""Pipeline orchestration modules."""

--- a/app/pipeline/bat.py
+++ b/app/pipeline/bat.py
@@ -1,0 +1,132 @@
+import logging
+from dataclasses import dataclass
+
+from bs4 import BeautifulSoup
+
+from app.sources.bat.discovery import (
+    discover_completed_auctions,
+    load_pending_discovered_listings,
+    mark_discovered_listing_handled,
+)
+from app.sources.bat.ingest import (
+    evaluate_listing_eligibility,
+    fetch_listing_html,
+    save_listing_html,
+)
+from app.sources.bat.load import load_listing
+from app.sources.bat.transform import (
+    load_pending_raw_listing_html,
+    transform_listing_html,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BatchIngestSummary:
+    selected: int = 0
+    scrape_attempted: int = 0
+    scrape_failed: int = 0
+    rejected: int = 0
+    raw_html_stored: int = 0
+    accepted: int = 0
+
+
+@dataclass
+class BatchTransformSummary:
+    selected: int = 0
+    transformed_and_loaded: int = 0
+    transform_failed: int = 0
+    load_failed: int = 0
+
+
+def ingest_listing(listing_id):
+    html = fetch_listing_html(listing_id)
+    save_listing_html(listing_id, html)
+
+
+def transform_listing(listing_id):
+    transformed_listing = transform_listing_html(listing_id)
+    load_listing(transformed_listing)
+
+
+def run_listing(listing_id):
+    ingest_listing(listing_id)
+    transform_listing(listing_id)
+
+
+def discover_listings(scrape_date, max_candidates=None):
+    return discover_completed_auctions(
+        scrape_date=scrape_date,
+        max_candidates=max_candidates,
+    )
+
+
+def ingest_discovered_listings(batch_size=None):
+    summary = BatchIngestSummary()
+    pending_rows = load_pending_discovered_listings(limit=batch_size)
+
+    for row in pending_rows:
+        summary.selected += 1
+        listing_id = row["source_listing_id"]
+
+        summary.scrape_attempted += 1
+        try:
+            html = fetch_listing_html(listing_id)
+        except Exception:
+            summary.scrape_failed += 1
+            logger.error("BAT ingest-discovered scrape failed for listing_id=%s", listing_id)
+            continue
+
+        soup = BeautifulSoup(html, "html.parser")
+        eligible, reason = evaluate_listing_eligibility(soup, listing_id)
+        mark_discovered_listing_handled(listing_id, eligible, reason)
+        if not eligible:
+            logger.info(
+                "BAT ingest-discovered listing rejected for listing_id=%s reason=%s",
+                listing_id,
+                reason,
+            )
+            summary.rejected += 1
+            continue
+
+        save_listing_html(listing_id, html, url=row["url"])
+        summary.raw_html_stored += 1
+        summary.accepted += 1
+
+    return summary
+
+
+def transform_discovered_listings(batch_size=None):
+    summary = BatchTransformSummary()
+    pending_rows = load_pending_raw_listing_html(limit=batch_size)
+
+    for row in pending_rows:
+        summary.selected += 1
+        listing_id = row["source_listing_id"]
+
+        try:
+            transformed_listing = transform_listing_html(listing_id)
+        except Exception as exc:
+            summary.transform_failed += 1
+            logger.error(
+                "BAT transform-discovered row failed for listing_id=%s stage=transform error=%s",
+                listing_id,
+                exc,
+            )
+            continue
+
+        try:
+            load_listing(transformed_listing)
+        except Exception as exc:
+            summary.load_failed += 1
+            logger.error(
+                "BAT transform-discovered row failed for listing_id=%s stage=load error=%s",
+                listing_id,
+                exc,
+            )
+            continue
+
+        summary.transformed_and_loaded += 1
+
+    return summary

--- a/app/sources/bat/cli.py
+++ b/app/sources/bat/cli.py
@@ -1,48 +1,14 @@
 import argparse
 import logging
-from dataclasses import dataclass
 from datetime import date
 
-from bs4 import BeautifulSoup
 from dotenv import load_dotenv
 
-from app.sources.bat.discovery import (
-    discover_completed_auctions,
-    load_pending_discovered_listings,
-    mark_discovered_listing_handled,
-)
-from app.sources.bat.ingest import (
-    evaluate_listing_eligibility,
-    fetch_listing_html,
-    save_listing_html,
-)
-from app.sources.bat.load import load_listing
-from app.sources.bat.transform import (
-    load_pending_raw_listing_html,
-    transform_listing_html,
-)
+from app.pipeline import bat as bat_pipeline
 
 load_dotenv()
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class BatchIngestSummary:
-    selected: int = 0
-    scrape_attempted: int = 0
-    scrape_failed: int = 0
-    rejected: int = 0
-    raw_html_stored: int = 0
-    accepted: int = 0
-
-
-@dataclass
-class BatchTransformSummary:
-    selected: int = 0
-    transformed_and_loaded: int = 0
-    transform_failed: int = 0
-    load_failed: int = 0
 
 
 def build_parser():
@@ -77,98 +43,6 @@ def configure_logging():
     )
 
 
-def ingest_listing(listing_id):
-    html = fetch_listing_html(listing_id)
-    save_listing_html(listing_id, html)
-
-
-def transform_listing(listing_id):
-    transformed_listing = transform_listing_html(listing_id)
-    load_listing(transformed_listing)
-
-
-def run_listing(listing_id):
-    ingest_listing(listing_id)
-    transform_listing(listing_id)
-
-
-def discover_listings(scrape_date, max_candidates=None):
-    return discover_completed_auctions(
-        scrape_date=scrape_date,
-        max_candidates=max_candidates,
-    )
-
-
-def ingest_discovered_listings(batch_size=None):
-    summary = BatchIngestSummary()
-    pending_rows = load_pending_discovered_listings(limit=batch_size)
-
-    for row in pending_rows:
-        summary.selected += 1
-        listing_id = row["source_listing_id"]
-
-        summary.scrape_attempted += 1
-        try:
-            html = fetch_listing_html(listing_id)
-        except Exception:
-            summary.scrape_failed += 1
-            logger.error("BAT ingest-discovered scrape failed for listing_id=%s", listing_id)
-            continue
-
-        soup = BeautifulSoup(html, "html.parser")
-        eligible, reason = evaluate_listing_eligibility(soup, listing_id)
-        mark_discovered_listing_handled(listing_id, eligible, reason)
-        if not eligible:
-            logger.info(
-                "BAT ingest-discovered listing rejected for listing_id=%s reason=%s",
-                listing_id,
-                reason,
-            )
-            summary.rejected += 1
-            continue
-
-        save_listing_html(listing_id, html, url=row["url"])
-        summary.raw_html_stored += 1
-        summary.accepted += 1
-
-    return summary
-
-
-def transform_discovered_listings(batch_size=None):
-    summary = BatchTransformSummary()
-    pending_rows = load_pending_raw_listing_html(limit=batch_size)
-
-    for row in pending_rows:
-        summary.selected += 1
-        listing_id = row["source_listing_id"]
-
-        try:
-            transformed_listing = transform_listing_html(listing_id)
-        except Exception as exc:
-            summary.transform_failed += 1
-            logger.error(
-                "BAT transform-discovered row failed for listing_id=%s stage=transform error=%s",
-                listing_id,
-                exc,
-            )
-            continue
-
-        try:
-            load_listing(transformed_listing)
-        except Exception as exc:
-            summary.load_failed += 1
-            logger.error(
-                "BAT transform-discovered row failed for listing_id=%s stage=load error=%s",
-                listing_id,
-                exc,
-            )
-            continue
-
-        summary.transformed_and_loaded += 1
-
-    return summary
-
-
 def main(argv=None):
     configure_logging()
     args = build_parser().parse_args(argv)
@@ -180,7 +54,7 @@ def main(argv=None):
                 args.scrape_date.isoformat(),
                 args.max_candidates,
             )
-            summary = discover_listings(
+            summary = bat_pipeline.discover_listings(
                 scrape_date=args.scrape_date,
                 max_candidates=args.max_candidates,
             )
@@ -208,7 +82,7 @@ def main(argv=None):
                 "BAT ingest-discovered command started for batch_size=%s",
                 args.batch_size,
             )
-            summary = ingest_discovered_listings(batch_size=args.batch_size)
+            summary = bat_pipeline.ingest_discovered_listings(batch_size=args.batch_size)
             logger.info(
                 "BAT ingest-discovered summary selected=%s scrape_attempted=%s scrape_failed=%s rejected=%s raw_html_stored=%s accepted=%s",
                 summary.selected,
@@ -234,7 +108,7 @@ def main(argv=None):
                 "BAT transform-discovered command started for batch_size=%s",
                 args.batch_size,
             )
-            summary = transform_discovered_listings(batch_size=args.batch_size)
+            summary = bat_pipeline.transform_discovered_listings(batch_size=args.batch_size)
             logger.info(
                 "BAT transform-discovered summary selected=%s transformed_and_loaded=%s transform_failed=%s load_failed=%s",
                 summary.selected,
@@ -257,11 +131,11 @@ def main(argv=None):
 
         logger.info("BAT %s command started for listing_id=%s", args.command, args.listing_id)
         if args.command == "ingest":
-            ingest_listing(args.listing_id)
+            bat_pipeline.ingest_listing(args.listing_id)
         elif args.command == "transform":
-            transform_listing(args.listing_id)
+            bat_pipeline.transform_listing(args.listing_id)
         elif args.command == "run":
-            run_listing(args.listing_id)
+            bat_pipeline.run_listing(args.listing_id)
     except Exception:
         if args.command == "discover":
             logger.error(

--- a/tests/integration/bat/test_transform_discovered_integration.py
+++ b/tests/integration/bat/test_transform_discovered_integration.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import psycopg
 import pytest
 
-from app.sources.bat import cli
+from app.pipeline import bat
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -98,8 +98,8 @@ def test_transform_discovered_processes_successes_retains_failures_and_respects_
         monkeypatch.setenv("DATABASE_URL", database_url)
         _insert_raw_listing_rows(database_url)
 
-        first_summary = cli.transform_discovered_listings(batch_size=2)
-        assert first_summary == cli.BatchTransformSummary(
+        first_summary = bat.transform_discovered_listings(batch_size=2)
+        assert first_summary == bat.BatchTransformSummary(
             selected=2,
             transformed_and_loaded=1,
             transform_failed=1,
@@ -113,8 +113,8 @@ def test_transform_discovered_processes_successes_retains_failures_and_respects_
         ]
         assert _listing_ids(database_url) == ["2004-first-success"]
 
-        second_summary = cli.transform_discovered_listings()
-        assert second_summary == cli.BatchTransformSummary(
+        second_summary = bat.transform_discovered_listings()
+        assert second_summary == bat.BatchTransformSummary(
             selected=2,
             transformed_and_loaded=1,
             transform_failed=1,

--- a/tests/unit/bat/test_cli.py
+++ b/tests/unit/bat/test_cli.py
@@ -3,30 +3,25 @@ from datetime import date
 
 import pytest
 
+from app.pipeline import bat
 from app.sources.bat import cli
 
 
 def test_ingest_command_fetches_and_saves_listing_html(mocker, caplog):
-    fetch_listing_html = mocker.patch(
-        "app.sources.bat.cli.fetch_listing_html",
-        return_value="<html>Test</html>",
-    )
-    save_listing_html = mocker.patch("app.sources.bat.cli.save_listing_html")
+    ingest_listing = mocker.patch("app.sources.bat.cli.bat_pipeline.ingest_listing")
 
     caplog.set_level(logging.INFO)
     cli.main(["ingest", "--listing-id", "test-id"])
 
-    fetch_listing_html.assert_called_once_with("test-id")
-    save_listing_html.assert_called_once_with("test-id", "<html>Test</html>")
+    ingest_listing.assert_called_once_with("test-id")
     assert "BAT ingest command started for listing_id=test-id" in caplog.text
     assert "BAT ingest command completed for listing_id=test-id" in caplog.text
-    assert "<html>Test</html>" not in caplog.text
 
 
 def test_transform_command_logs_failure_context_without_traceback_and_reraises(mocker, caplog):
     error = RuntimeError("transform failed")
     mocker.patch(
-        "app.sources.bat.cli.transform_listing_html",
+        "app.sources.bat.cli.bat_pipeline.transform_listing",
         side_effect=error,
     )
 
@@ -42,34 +37,11 @@ def test_transform_command_logs_failure_context_without_traceback_and_reraises(m
 
 
 def test_run_command_executes_ingest_transform_load_in_order(mocker):
-    calls = []
-    transformed_listing = {"listing_id": "test-id"}
-
-    mocker.patch(
-        "app.sources.bat.cli.fetch_listing_html",
-        side_effect=lambda listing_id: calls.append(("fetch", listing_id)) or "<html>Test</html>",
-    )
-    mocker.patch(
-        "app.sources.bat.cli.save_listing_html",
-        side_effect=lambda listing_id, html: calls.append(("save", listing_id, html)),
-    )
-    mocker.patch(
-        "app.sources.bat.cli.transform_listing_html",
-        side_effect=lambda listing_id: calls.append(("transform", listing_id)) or transformed_listing,
-    )
-    mocker.patch(
-        "app.sources.bat.cli.load_listing",
-        side_effect=lambda listing: calls.append(("load", listing)),
-    )
+    run_listing = mocker.patch("app.sources.bat.cli.bat_pipeline.run_listing")
 
     cli.main(["run", "--listing-id", "test-id"])
 
-    assert calls == [
-        ("fetch", "test-id"),
-        ("save", "test-id", "<html>Test</html>"),
-        ("transform", "test-id"),
-        ("load", transformed_listing),
-    ]
+    run_listing.assert_called_once_with("test-id")
 
 
 def test_discover_command_parses_without_listing_id():
@@ -81,8 +53,8 @@ def test_discover_command_parses_without_listing_id():
 
 
 def test_discover_command_dispatches_with_parsed_options(mocker, caplog, capsys):
-    discover_completed_auctions = mocker.patch(
-        "app.sources.bat.cli.discover_completed_auctions",
+    discover_listings = mocker.patch(
+        "app.sources.bat.cli.bat_pipeline.discover_listings",
         return_value=mocker.Mock(
             candidates_inspected=2,
             newly_discovered=1,
@@ -102,7 +74,7 @@ def test_discover_command_dispatches_with_parsed_options(mocker, caplog, capsys)
         ]
     )
 
-    discover_completed_auctions.assert_called_once_with(
+    discover_listings.assert_called_once_with(
         scrape_date=date(2026, 4, 20),
         max_candidates=5,
     )
@@ -120,7 +92,7 @@ def test_discover_command_dispatches_with_parsed_options(mocker, caplog, capsys)
 def test_discover_command_logs_failure_context_without_traceback_and_reraises(mocker, caplog):
     error = RuntimeError("discover failed")
     mocker.patch(
-        "app.sources.bat.cli.discover_completed_auctions",
+        "app.sources.bat.cli.bat_pipeline.discover_listings",
         side_effect=error,
     )
 
@@ -173,8 +145,8 @@ def test_transform_discovered_command_parses_with_batch_size():
 
 def test_ingest_discovered_command_dispatches_with_parsed_options(mocker, caplog, capsys):
     ingest_discovered_listings = mocker.patch(
-        "app.sources.bat.cli.ingest_discovered_listings",
-        return_value=cli.BatchIngestSummary(
+        "app.sources.bat.cli.bat_pipeline.ingest_discovered_listings",
+        return_value=bat.BatchIngestSummary(
             selected=3,
             scrape_attempted=2,
             scrape_failed=1,
@@ -205,7 +177,7 @@ def test_ingest_discovered_command_logs_failure_context_without_traceback_and_re
 ):
     error = RuntimeError("ingest-discovered failed")
     mocker.patch(
-        "app.sources.bat.cli.ingest_discovered_listings",
+        "app.sources.bat.cli.bat_pipeline.ingest_discovered_listings",
         side_effect=error,
     )
 
@@ -222,8 +194,8 @@ def test_ingest_discovered_command_logs_failure_context_without_traceback_and_re
 
 def test_transform_discovered_command_dispatches_with_parsed_options(mocker, caplog, capsys):
     transform_discovered_listings = mocker.patch(
-        "app.sources.bat.cli.transform_discovered_listings",
-        return_value=cli.BatchTransformSummary(
+        "app.sources.bat.cli.bat_pipeline.transform_discovered_listings",
+        return_value=bat.BatchTransformSummary(
             selected=3,
             transformed_and_loaded=1,
             transform_failed=1,
@@ -252,7 +224,7 @@ def test_transform_discovered_command_logs_failure_context_without_traceback_and
 ):
     error = RuntimeError("transform-discovered failed")
     mocker.patch(
-        "app.sources.bat.cli.transform_discovered_listings",
+        "app.sources.bat.cli.bat_pipeline.transform_discovered_listings",
         side_effect=error,
     )
 
@@ -265,351 +237,6 @@ def test_transform_discovered_command_logs_failure_context_without_traceback_and
     assert "BAT transform-discovered command failed for batch_size=5" in caplog.text
     assert "Traceback" not in caplog.text
     assert "RuntimeError: transform-discovered failed" not in caplog.text
-
-
-def test_ingest_discovered_listings_returns_zeroed_summary_for_empty_batch(mocker):
-    mocker.patch(
-        "app.sources.bat.cli.load_pending_discovered_listings",
-        return_value=[],
-    )
-
-    summary = cli.ingest_discovered_listings()
-
-    assert summary == cli.BatchIngestSummary()
-
-
-def test_transform_discovered_listings_returns_zeroed_summary_for_empty_batch(mocker):
-    mocker.patch(
-        "app.sources.bat.cli.load_pending_raw_listing_html",
-        return_value=[],
-    )
-
-    summary = cli.transform_discovered_listings()
-
-    assert summary == cli.BatchTransformSummary()
-
-
-def test_ingest_discovered_listings_marks_reject_without_saving_html(mocker, caplog):
-    mocker.patch(
-        "app.sources.bat.cli.load_pending_discovered_listings",
-        return_value=[
-            {
-                "source_listing_id": "rejected",
-                "title": "1940 Ford Coupe",
-                "url": "https://bringatrailer.com/listing/rejected/",
-            }
-        ],
-    )
-    mocker.patch(
-        "app.sources.bat.cli.fetch_listing_html",
-        return_value="<html><body>listing</body></html>",
-    )
-    evaluate_listing_eligibility = mocker.patch(
-        "app.sources.bat.cli.evaluate_listing_eligibility",
-        return_value=(False, "year before 1946"),
-    )
-    mark_handled = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled")
-    save_listing_html = mocker.patch("app.sources.bat.cli.save_listing_html")
-
-    caplog.set_level(logging.INFO)
-    summary = cli.ingest_discovered_listings()
-
-    evaluate_listing_eligibility.assert_called_once()
-    _, listing_id = evaluate_listing_eligibility.call_args.args
-    assert listing_id == "rejected"
-    mark_handled.assert_called_once_with("rejected", False, "year before 1946")
-    save_listing_html.assert_not_called()
-    assert (
-        "BAT ingest-discovered listing rejected for listing_id=rejected "
-        "reason=year before 1946"
-    ) in caplog.text
-    assert summary == cli.BatchIngestSummary(
-        selected=1,
-        scrape_attempted=1,
-        rejected=1,
-    )
-
-
-def test_ingest_discovered_listings_records_scrape_failure_without_marking_row(mocker):
-    mocker.patch(
-        "app.sources.bat.cli.load_pending_discovered_listings",
-        return_value=[
-            {
-                "source_listing_id": "scrape-fail",
-                "title": "1967 Porsche 911S Coupe",
-                "url": "https://bringatrailer.com/listing/scrape-fail/",
-            }
-        ],
-    )
-    mocker.patch(
-        "app.sources.bat.cli.fetch_listing_html",
-        side_effect=RuntimeError("network failed"),
-    )
-    mark_handled = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled")
-
-    summary = cli.ingest_discovered_listings()
-
-    mark_handled.assert_not_called()
-    assert summary == cli.BatchIngestSummary(
-        selected=1,
-        scrape_attempted=1,
-        scrape_failed=1,
-    )
-
-
-def test_ingest_discovered_listings_marks_category_reject_without_saving_html(mocker, caplog):
-    mocker.patch(
-        "app.sources.bat.cli.load_pending_discovered_listings",
-        return_value=[
-            {
-                "source_listing_id": "category-reject",
-                "title": "1967 Porsche 911S Coupe",
-                "url": "https://bringatrailer.com/listing/category-reject/",
-            }
-        ],
-    )
-    mocker.patch(
-        "app.sources.bat.cli.fetch_listing_html",
-        return_value="<html><body>listing</body></html>",
-    )
-    evaluate_listing_eligibility = mocker.patch(
-        "app.sources.bat.cli.evaluate_listing_eligibility",
-        return_value=(False, "excluded category: projects"),
-    )
-    mark_handled = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled")
-    save_listing_html = mocker.patch("app.sources.bat.cli.save_listing_html")
-
-    caplog.set_level(logging.INFO)
-    summary = cli.ingest_discovered_listings()
-
-    evaluate_listing_eligibility.assert_called_once()
-    _, listing_id = evaluate_listing_eligibility.call_args.args
-    assert listing_id == "category-reject"
-    mark_handled.assert_called_once_with(
-        "category-reject",
-        False,
-        "excluded category: projects",
-    )
-    save_listing_html.assert_not_called()
-    assert (
-        "BAT ingest-discovered listing rejected for listing_id=category-reject "
-        "reason=excluded category: projects"
-    ) in caplog.text
-    assert summary == cli.BatchIngestSummary(
-        selected=1,
-        scrape_attempted=1,
-        rejected=1,
-    )
-
-
-def test_ingest_discovered_listings_saves_html_and_marks_eligible_for_pass(mocker):
-    mocker.patch(
-        "app.sources.bat.cli.load_pending_discovered_listings",
-        return_value=[
-            {
-                "source_listing_id": "accepted",
-                "title": "1967 Porsche 911S Coupe",
-                "url": "https://bringatrailer.com/listing/accepted/",
-            }
-        ],
-    )
-    mocker.patch(
-        "app.sources.bat.cli.fetch_listing_html",
-        return_value="<html><body>listing</body></html>",
-    )
-    mocker.patch(
-        "app.sources.bat.cli.evaluate_listing_eligibility",
-        return_value=(True, None),
-    )
-    save_listing_html = mocker.patch("app.sources.bat.cli.save_listing_html")
-    mark_handled = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled")
-    calls = mocker.Mock()
-    calls.attach_mock(save_listing_html, "save_listing_html")
-    calls.attach_mock(mark_handled, "mark_handled")
-
-    summary = cli.ingest_discovered_listings()
-
-    save_listing_html.assert_called_once_with(
-        "accepted",
-        "<html><body>listing</body></html>",
-        url="https://bringatrailer.com/listing/accepted/",
-    )
-    mark_handled.assert_called_once_with("accepted", True, None)
-    assert calls.mock_calls == [
-        mocker.call.mark_handled("accepted", True, None),
-        mocker.call.save_listing_html(
-            "accepted",
-            "<html><body>listing</body></html>",
-            url="https://bringatrailer.com/listing/accepted/",
-        ),
-    ]
-    assert summary == cli.BatchIngestSummary(
-        selected=1,
-        scrape_attempted=1,
-        raw_html_stored=1,
-        accepted=1,
-    )
-
-
-def test_ingest_discovered_listings_uses_listing_id_when_discovered_title_missing(mocker):
-    mocker.patch(
-        "app.sources.bat.cli.load_pending_discovered_listings",
-        return_value=[
-            {
-                "source_listing_id": "1967-fallback-title",
-                "title": None,
-                "url": "https://bringatrailer.com/listing/1967-fallback-title/",
-            }
-        ],
-    )
-    mocker.patch(
-        "app.sources.bat.cli.fetch_listing_html",
-        return_value="<html><body>listing</body></html>",
-    )
-    evaluate_listing_eligibility = mocker.patch(
-        "app.sources.bat.cli.evaluate_listing_eligibility",
-        return_value=(True, None),
-    )
-    mocker.patch("app.sources.bat.cli.save_listing_html")
-    mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled")
-
-    cli.ingest_discovered_listings()
-
-    evaluate_listing_eligibility.assert_called_once()
-    _, listing_id = evaluate_listing_eligibility.call_args.args
-    assert listing_id == "1967-fallback-title"
-
-
-def test_ingest_discovered_listings_handles_mixed_batch_outcomes(mocker):
-    mocker.patch(
-        "app.sources.bat.cli.load_pending_discovered_listings",
-        return_value=[
-            {
-                "source_listing_id": "year-reject",
-                "title": "1940 Ford Coupe",
-                "url": "https://bringatrailer.com/listing/year-reject/",
-            },
-            {
-                "source_listing_id": "scrape-fail",
-                "title": "1967 Porsche 911S Coupe",
-                "url": "https://bringatrailer.com/listing/scrape-fail/",
-            },
-            {
-                "source_listing_id": "category-reject",
-                "title": "1969 Porsche 911E Coupe",
-                "url": "https://bringatrailer.com/listing/category-reject/",
-            },
-            {
-                "source_listing_id": "accepted",
-                "title": "1970 Porsche 911T Coupe",
-                "url": "https://bringatrailer.com/listing/accepted/",
-            },
-        ],
-    )
-    mocker.patch(
-        "app.sources.bat.cli.fetch_listing_html",
-        side_effect=[
-            "<html><body>year reject</body></html>",
-            RuntimeError("network failed"),
-            "<html><body>category reject</body></html>",
-            "<html><body>accepted</body></html>",
-        ],
-    )
-    mocker.patch(
-        "app.sources.bat.cli.evaluate_listing_eligibility",
-        side_effect=[
-            (False, "year before 1946"),
-            (False, "excluded category: projects"),
-            (True, None),
-        ],
-    )
-    save_listing_html = mocker.patch("app.sources.bat.cli.save_listing_html")
-    mark_handled = mocker.patch("app.sources.bat.cli.mark_discovered_listing_handled")
-    calls = mocker.Mock()
-    calls.attach_mock(save_listing_html, "save_listing_html")
-    calls.attach_mock(mark_handled, "mark_handled")
-
-    summary = cli.ingest_discovered_listings()
-
-    assert summary == cli.BatchIngestSummary(
-        selected=4,
-        scrape_attempted=4,
-        scrape_failed=1,
-        rejected=2,
-        raw_html_stored=1,
-        accepted=1,
-    )
-    assert mark_handled.call_args_list == [
-        mocker.call("year-reject", False, "year before 1946"),
-        mocker.call("category-reject", False, "excluded category: projects"),
-        mocker.call("accepted", True, None),
-    ]
-    save_listing_html.assert_called_once_with(
-        "accepted",
-        "<html><body>accepted</body></html>",
-        url="https://bringatrailer.com/listing/accepted/",
-    )
-    assert calls.mock_calls[-2:] == [
-        mocker.call.mark_handled("accepted", True, None),
-        mocker.call.save_listing_html(
-            "accepted",
-            "<html><body>accepted</body></html>",
-            url="https://bringatrailer.com/listing/accepted/",
-        ),
-    ]
-
-
-def test_transform_discovered_listings_handles_mixed_batch_outcomes(mocker, caplog):
-    mocker.patch(
-        "app.sources.bat.cli.load_pending_raw_listing_html",
-        return_value=[
-            {"source_listing_id": "transform-fail"},
-            {"source_listing_id": "load-fail"},
-            {"source_listing_id": "success"},
-        ],
-    )
-    transformed_load_fail = {"listing_id": "load-fail"}
-    transformed_success = {"listing_id": "success"}
-    mocker.patch(
-        "app.sources.bat.cli.transform_listing_html",
-        side_effect=[
-            RuntimeError("missing raw html"),
-            transformed_load_fail,
-            transformed_success,
-        ],
-    )
-    load_listing = mocker.patch(
-        "app.sources.bat.cli.load_listing",
-        side_effect=[
-            RuntimeError("constraint violation"),
-            None,
-        ],
-    )
-
-    caplog.set_level(logging.ERROR)
-    summary = cli.transform_discovered_listings(batch_size=3)
-
-    load_listing.assert_has_calls(
-        [
-            mocker.call(transformed_load_fail),
-            mocker.call(transformed_success),
-        ]
-    )
-    assert summary == cli.BatchTransformSummary(
-        selected=3,
-        transformed_and_loaded=1,
-        transform_failed=1,
-        load_failed=1,
-    )
-    assert (
-        "BAT transform-discovered row failed for listing_id=transform-fail "
-        "stage=transform error=missing raw html"
-    ) in caplog.text
-    assert (
-        "BAT transform-discovered row failed for listing_id=load-fail "
-        "stage=load error=constraint violation"
-    ) in caplog.text
-    assert "Traceback" not in caplog.text
 
 
 @pytest.mark.parametrize("command", ["ingest", "transform", "run"])

--- a/tests/unit/bat/test_pipeline.py
+++ b/tests/unit/bat/test_pipeline.py
@@ -1,0 +1,418 @@
+import logging
+from datetime import date
+
+from app.pipeline import bat
+
+
+def test_ingest_listing_fetches_and_saves_listing_html(mocker):
+    fetch_listing_html = mocker.patch(
+        "app.pipeline.bat.fetch_listing_html",
+        return_value="<html>Test</html>",
+    )
+    save_listing_html = mocker.patch("app.pipeline.bat.save_listing_html")
+
+    bat.ingest_listing("test-id")
+
+    fetch_listing_html.assert_called_once_with("test-id")
+    save_listing_html.assert_called_once_with("test-id", "<html>Test</html>")
+
+
+def test_transform_listing_transforms_and_loads_listing(mocker):
+    transformed_listing = {"listing_id": "test-id"}
+    transform_listing_html = mocker.patch(
+        "app.pipeline.bat.transform_listing_html",
+        return_value=transformed_listing,
+    )
+    load_listing = mocker.patch("app.pipeline.bat.load_listing")
+
+    bat.transform_listing("test-id")
+
+    transform_listing_html.assert_called_once_with("test-id")
+    load_listing.assert_called_once_with(transformed_listing)
+
+
+def test_run_listing_executes_ingest_transform_load_in_order(mocker):
+    calls = []
+    transformed_listing = {"listing_id": "test-id"}
+
+    mocker.patch(
+        "app.pipeline.bat.fetch_listing_html",
+        side_effect=lambda listing_id: calls.append(("fetch", listing_id)) or "<html>Test</html>",
+    )
+    mocker.patch(
+        "app.pipeline.bat.save_listing_html",
+        side_effect=lambda listing_id, html: calls.append(("save", listing_id, html)),
+    )
+    mocker.patch(
+        "app.pipeline.bat.transform_listing_html",
+        side_effect=lambda listing_id: calls.append(("transform", listing_id)) or transformed_listing,
+    )
+    mocker.patch(
+        "app.pipeline.bat.load_listing",
+        side_effect=lambda listing: calls.append(("load", listing)),
+    )
+
+    bat.run_listing("test-id")
+
+    assert calls == [
+        ("fetch", "test-id"),
+        ("save", "test-id", "<html>Test</html>"),
+        ("transform", "test-id"),
+        ("load", transformed_listing),
+    ]
+
+
+def test_discover_listings_delegates_to_discovery(mocker):
+    discover_completed_auctions = mocker.patch("app.pipeline.bat.discover_completed_auctions")
+
+    bat.discover_listings(scrape_date=date(2026, 4, 20), max_candidates=5)
+
+    discover_completed_auctions.assert_called_once_with(
+        scrape_date=date(2026, 4, 20),
+        max_candidates=5,
+    )
+
+
+def test_ingest_discovered_listings_returns_zeroed_summary_for_empty_batch(mocker):
+    mocker.patch(
+        "app.pipeline.bat.load_pending_discovered_listings",
+        return_value=[],
+    )
+
+    summary = bat.ingest_discovered_listings()
+
+    assert summary == bat.BatchIngestSummary()
+
+
+def test_transform_discovered_listings_returns_zeroed_summary_for_empty_batch(mocker):
+    mocker.patch(
+        "app.pipeline.bat.load_pending_raw_listing_html",
+        return_value=[],
+    )
+
+    summary = bat.transform_discovered_listings()
+
+    assert summary == bat.BatchTransformSummary()
+
+
+def test_ingest_discovered_listings_marks_reject_without_saving_html(mocker, caplog):
+    mocker.patch(
+        "app.pipeline.bat.load_pending_discovered_listings",
+        return_value=[
+            {
+                "source_listing_id": "rejected",
+                "title": "1940 Ford Coupe",
+                "url": "https://bringatrailer.com/listing/rejected/",
+            }
+        ],
+    )
+    mocker.patch(
+        "app.pipeline.bat.fetch_listing_html",
+        return_value="<html><body>listing</body></html>",
+    )
+    evaluate_listing_eligibility = mocker.patch(
+        "app.pipeline.bat.evaluate_listing_eligibility",
+        return_value=(False, "year before 1946"),
+    )
+    mark_handled = mocker.patch("app.pipeline.bat.mark_discovered_listing_handled")
+    save_listing_html = mocker.patch("app.pipeline.bat.save_listing_html")
+
+    caplog.set_level(logging.INFO)
+    summary = bat.ingest_discovered_listings()
+
+    evaluate_listing_eligibility.assert_called_once()
+    _, listing_id = evaluate_listing_eligibility.call_args.args
+    assert listing_id == "rejected"
+    mark_handled.assert_called_once_with("rejected", False, "year before 1946")
+    save_listing_html.assert_not_called()
+    assert (
+        "BAT ingest-discovered listing rejected for listing_id=rejected "
+        "reason=year before 1946"
+    ) in caplog.text
+    assert summary == bat.BatchIngestSummary(
+        selected=1,
+        scrape_attempted=1,
+        rejected=1,
+    )
+
+
+def test_ingest_discovered_listings_records_scrape_failure_without_marking_row(mocker):
+    mocker.patch(
+        "app.pipeline.bat.load_pending_discovered_listings",
+        return_value=[
+            {
+                "source_listing_id": "scrape-fail",
+                "title": "1967 Porsche 911S Coupe",
+                "url": "https://bringatrailer.com/listing/scrape-fail/",
+            }
+        ],
+    )
+    mocker.patch(
+        "app.pipeline.bat.fetch_listing_html",
+        side_effect=RuntimeError("network failed"),
+    )
+    mark_handled = mocker.patch("app.pipeline.bat.mark_discovered_listing_handled")
+
+    summary = bat.ingest_discovered_listings()
+
+    mark_handled.assert_not_called()
+    assert summary == bat.BatchIngestSummary(
+        selected=1,
+        scrape_attempted=1,
+        scrape_failed=1,
+    )
+
+
+def test_ingest_discovered_listings_marks_category_reject_without_saving_html(mocker, caplog):
+    mocker.patch(
+        "app.pipeline.bat.load_pending_discovered_listings",
+        return_value=[
+            {
+                "source_listing_id": "category-reject",
+                "title": "1967 Porsche 911S Coupe",
+                "url": "https://bringatrailer.com/listing/category-reject/",
+            }
+        ],
+    )
+    mocker.patch(
+        "app.pipeline.bat.fetch_listing_html",
+        return_value="<html><body>listing</body></html>",
+    )
+    evaluate_listing_eligibility = mocker.patch(
+        "app.pipeline.bat.evaluate_listing_eligibility",
+        return_value=(False, "excluded category: projects"),
+    )
+    mark_handled = mocker.patch("app.pipeline.bat.mark_discovered_listing_handled")
+    save_listing_html = mocker.patch("app.pipeline.bat.save_listing_html")
+
+    caplog.set_level(logging.INFO)
+    summary = bat.ingest_discovered_listings()
+
+    evaluate_listing_eligibility.assert_called_once()
+    _, listing_id = evaluate_listing_eligibility.call_args.args
+    assert listing_id == "category-reject"
+    mark_handled.assert_called_once_with(
+        "category-reject",
+        False,
+        "excluded category: projects",
+    )
+    save_listing_html.assert_not_called()
+    assert (
+        "BAT ingest-discovered listing rejected for listing_id=category-reject "
+        "reason=excluded category: projects"
+    ) in caplog.text
+    assert summary == bat.BatchIngestSummary(
+        selected=1,
+        scrape_attempted=1,
+        rejected=1,
+    )
+
+
+def test_ingest_discovered_listings_saves_html_and_marks_eligible_for_pass(mocker):
+    mocker.patch(
+        "app.pipeline.bat.load_pending_discovered_listings",
+        return_value=[
+            {
+                "source_listing_id": "accepted",
+                "title": "1967 Porsche 911S Coupe",
+                "url": "https://bringatrailer.com/listing/accepted/",
+            }
+        ],
+    )
+    mocker.patch(
+        "app.pipeline.bat.fetch_listing_html",
+        return_value="<html><body>listing</body></html>",
+    )
+    mocker.patch(
+        "app.pipeline.bat.evaluate_listing_eligibility",
+        return_value=(True, None),
+    )
+    save_listing_html = mocker.patch("app.pipeline.bat.save_listing_html")
+    mark_handled = mocker.patch("app.pipeline.bat.mark_discovered_listing_handled")
+    calls = mocker.Mock()
+    calls.attach_mock(save_listing_html, "save_listing_html")
+    calls.attach_mock(mark_handled, "mark_handled")
+
+    summary = bat.ingest_discovered_listings()
+
+    save_listing_html.assert_called_once_with(
+        "accepted",
+        "<html><body>listing</body></html>",
+        url="https://bringatrailer.com/listing/accepted/",
+    )
+    mark_handled.assert_called_once_with("accepted", True, None)
+    assert calls.mock_calls == [
+        mocker.call.mark_handled("accepted", True, None),
+        mocker.call.save_listing_html(
+            "accepted",
+            "<html><body>listing</body></html>",
+            url="https://bringatrailer.com/listing/accepted/",
+        ),
+    ]
+    assert summary == bat.BatchIngestSummary(
+        selected=1,
+        scrape_attempted=1,
+        raw_html_stored=1,
+        accepted=1,
+    )
+
+
+def test_ingest_discovered_listings_uses_listing_id_when_discovered_title_missing(mocker):
+    mocker.patch(
+        "app.pipeline.bat.load_pending_discovered_listings",
+        return_value=[
+            {
+                "source_listing_id": "1967-fallback-title",
+                "title": None,
+                "url": "https://bringatrailer.com/listing/1967-fallback-title/",
+            }
+        ],
+    )
+    mocker.patch(
+        "app.pipeline.bat.fetch_listing_html",
+        return_value="<html><body>listing</body></html>",
+    )
+    evaluate_listing_eligibility = mocker.patch(
+        "app.pipeline.bat.evaluate_listing_eligibility",
+        return_value=(True, None),
+    )
+    mocker.patch("app.pipeline.bat.save_listing_html")
+    mocker.patch("app.pipeline.bat.mark_discovered_listing_handled")
+
+    bat.ingest_discovered_listings()
+
+    evaluate_listing_eligibility.assert_called_once()
+    _, listing_id = evaluate_listing_eligibility.call_args.args
+    assert listing_id == "1967-fallback-title"
+
+
+def test_ingest_discovered_listings_handles_mixed_batch_outcomes(mocker):
+    mocker.patch(
+        "app.pipeline.bat.load_pending_discovered_listings",
+        return_value=[
+            {
+                "source_listing_id": "year-reject",
+                "title": "1940 Ford Coupe",
+                "url": "https://bringatrailer.com/listing/year-reject/",
+            },
+            {
+                "source_listing_id": "scrape-fail",
+                "title": "1967 Porsche 911S Coupe",
+                "url": "https://bringatrailer.com/listing/scrape-fail/",
+            },
+            {
+                "source_listing_id": "category-reject",
+                "title": "1969 Porsche 911E Coupe",
+                "url": "https://bringatrailer.com/listing/category-reject/",
+            },
+            {
+                "source_listing_id": "accepted",
+                "title": "1970 Porsche 911T Coupe",
+                "url": "https://bringatrailer.com/listing/accepted/",
+            },
+        ],
+    )
+    mocker.patch(
+        "app.pipeline.bat.fetch_listing_html",
+        side_effect=[
+            "<html><body>year reject</body></html>",
+            RuntimeError("network failed"),
+            "<html><body>category reject</body></html>",
+            "<html><body>accepted</body></html>",
+        ],
+    )
+    mocker.patch(
+        "app.pipeline.bat.evaluate_listing_eligibility",
+        side_effect=[
+            (False, "year before 1946"),
+            (False, "excluded category: projects"),
+            (True, None),
+        ],
+    )
+    save_listing_html = mocker.patch("app.pipeline.bat.save_listing_html")
+    mark_handled = mocker.patch("app.pipeline.bat.mark_discovered_listing_handled")
+    calls = mocker.Mock()
+    calls.attach_mock(save_listing_html, "save_listing_html")
+    calls.attach_mock(mark_handled, "mark_handled")
+
+    summary = bat.ingest_discovered_listings()
+
+    assert summary == bat.BatchIngestSummary(
+        selected=4,
+        scrape_attempted=4,
+        scrape_failed=1,
+        rejected=2,
+        raw_html_stored=1,
+        accepted=1,
+    )
+    assert mark_handled.call_args_list == [
+        mocker.call("year-reject", False, "year before 1946"),
+        mocker.call("category-reject", False, "excluded category: projects"),
+        mocker.call("accepted", True, None),
+    ]
+    save_listing_html.assert_called_once_with(
+        "accepted",
+        "<html><body>accepted</body></html>",
+        url="https://bringatrailer.com/listing/accepted/",
+    )
+    assert calls.mock_calls[-2:] == [
+        mocker.call.mark_handled("accepted", True, None),
+        mocker.call.save_listing_html(
+            "accepted",
+            "<html><body>accepted</body></html>",
+            url="https://bringatrailer.com/listing/accepted/",
+        ),
+    ]
+
+
+def test_transform_discovered_listings_handles_mixed_batch_outcomes(mocker, caplog):
+    mocker.patch(
+        "app.pipeline.bat.load_pending_raw_listing_html",
+        return_value=[
+            {"source_listing_id": "transform-fail"},
+            {"source_listing_id": "load-fail"},
+            {"source_listing_id": "success"},
+        ],
+    )
+    transformed_load_fail = {"listing_id": "load-fail"}
+    transformed_success = {"listing_id": "success"}
+    mocker.patch(
+        "app.pipeline.bat.transform_listing_html",
+        side_effect=[
+            RuntimeError("missing raw html"),
+            transformed_load_fail,
+            transformed_success,
+        ],
+    )
+    load_listing = mocker.patch(
+        "app.pipeline.bat.load_listing",
+        side_effect=[
+            RuntimeError("constraint violation"),
+            None,
+        ],
+    )
+
+    caplog.set_level(logging.ERROR)
+    summary = bat.transform_discovered_listings(batch_size=3)
+
+    load_listing.assert_has_calls(
+        [
+            mocker.call(transformed_load_fail),
+            mocker.call(transformed_success),
+        ]
+    )
+    assert summary == bat.BatchTransformSummary(
+        selected=3,
+        transformed_and_loaded=1,
+        transform_failed=1,
+        load_failed=1,
+    )
+    assert (
+        "BAT transform-discovered row failed for listing_id=transform-fail "
+        "stage=transform error=missing raw html"
+    ) in caplog.text
+    assert (
+        "BAT transform-discovered row failed for listing_id=load-fail "
+        "stage=load error=constraint violation"
+    ) in caplog.text
+    assert "Traceback" not in caplog.text


### PR DESCRIPTION
## Summary
- Move Bring a Trailer ETL orchestration from the CLI into app.pipeline.bat.
- Keep the BAT CLI focused on parsing, logging, dispatch, and stdout summaries.
- Split tests so CLI tests patch the pipeline boundary and pipeline tests cover orchestration behavior.

## Validation
- .venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_cli.py: 18 passed
- .venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_pipeline.py: 13 passed
- .venv\Scripts\python.exe -m pytest -q tests\integration\bat\test_transform_discovered_integration.py: 1 skipped
- .venv\Scripts\python.exe -m pytest -q: 1 failed, 217 passed

Full-suite failure: tests/integration/bat/test_load_integration.py::test_discovery_helpers_select_pending_rows_and_persist_handled_state includes already-ingested in pending IDs. This is outside issue #105 scope.