### PR TITLE
[codex] Add Cars and Bids eligibility evaluation

### DIFF
--- a/app/sources/carsandbids/ingest.py
+++ b/app/sources/carsandbids/ingest.py
@@ -12,6 +12,9 @@ API_AUCTION_URL_BASE = "https://carsandbids.com/v2/autos/auctions"
 PAGE_LOAD_TIMEOUT_MS = 60_000
 API_RESPONSE_TIMEOUT_MS = 15_000
 logger = logging.getLogger(__name__)
+CARSANDBIDS_MIN_YEAR = 1946
+EXCLUDED_MODEL_VALUES = {"kart", "replica", "golf cart", "custom"}
+EXCLUDED_MAKE_VALUES = {"military vehicle", "other"}
 
 UPSERT_RAW_LISTING_JSON_SQL = """
 INSERT INTO raw_listing_json (
@@ -104,6 +107,40 @@ def fetch_listing_json(listing_id):
     return payload
 
 
+def evaluate_listing_eligibility(payload):
+    listing = payload.get("listing") or {}
+    model = listing.get("model")
+    make = listing.get("make")
+
+    if listing.get("is_not_car") is True:
+        return False, "listing marked not car"
+
+    if (
+        isinstance(model, str)
+        and _normalize_listing_value(model) in EXCLUDED_MODEL_VALUES
+    ):
+        return False, f"excluded model: {model}"
+
+    if (
+        isinstance(make, str)
+        and _normalize_listing_value(make) in EXCLUDED_MAKE_VALUES
+    ):
+        return False, f"excluded make: {make}"
+
+    if _normalize_listing_value(payload.get("status")) == "canceled":
+        return False, "listing canceled"
+
+    try:
+        year = int(listing.get("year"))
+    except (TypeError, ValueError):
+        return False, "listing year missing"
+
+    if year < CARSANDBIDS_MIN_YEAR:
+        return False, "year before 1946"
+
+    return True, None
+
+
 def build_raw_listing_json_params(listing_id, payload, url=None):
     return {
         "source_site": SOURCE_SITE,
@@ -127,3 +164,9 @@ def save_listing_json(listing_id, payload, url=None):
             logger.info(
                 "Saved Cars and Bids raw listing JSON for listing_id=%s", listing_id
             )
+
+
+def _normalize_listing_value(value):
+    if not isinstance(value, str):
+        return ""
+    return " ".join(value.lower().split())

--- a/tests/unit/carsandbids/test_ingest.py
+++ b/tests/unit/carsandbids/test_ingest.py
@@ -1,4 +1,6 @@
+import json
 import logging
+from pathlib import Path
 
 import pytest
 from psycopg.types.json import Jsonb
@@ -6,9 +8,25 @@ from psycopg.types.json import Jsonb
 from app.sources.carsandbids import ingest
 from app.sources.carsandbids.ingest import (
     build_listing_url,
+    evaluate_listing_eligibility,
     fetch_listing_json,
     save_listing_json,
 )
+
+
+def _eligible_payload(status="sold", listing=None):
+    payload = {
+        "status": status,
+        "listing": {
+            "year": 2013,
+            "make": "Porsche",
+            "model": "911",
+            "is_not_car": False,
+        },
+    }
+    if listing:
+        payload["listing"].update(listing)
+    return payload
 
 
 def test_build_listing_url_returns_public_auction_url():
@@ -16,6 +34,120 @@ def test_build_listing_url_returns_public_auction_url():
         build_listing_url("test-auction")
         == "https://carsandbids.com/auctions/test-auction"
     )
+
+
+def test_evaluate_listing_eligibility_accepts_fixture_payload():
+    payload = json.loads(
+        Path("tests/fixtures/carsandbids_listing.json").read_text(encoding="utf-8")
+    )
+
+    assert evaluate_listing_eligibility(payload) == (True, None)
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_reason"),
+    [
+        (
+            _eligible_payload(listing={"is_not_car": True}),
+            "listing marked not car",
+        ),
+        (_eligible_payload(listing={"model": "Kart"}), "excluded model: Kart"),
+        (
+            _eligible_payload(listing={"make": "Military Vehicle"}),
+            "excluded make: Military Vehicle",
+        ),
+        (_eligible_payload(status="canceled"), "listing canceled"),
+        (_eligible_payload(listing={"year": None}), "listing year missing"),
+        (_eligible_payload(listing={"year": "unknown"}), "listing year missing"),
+        (_eligible_payload(listing={"year": 1945}), "year before 1946"),
+    ],
+)
+def test_evaluate_listing_eligibility_rejects_ineligible_payloads(
+    payload, expected_reason
+):
+    assert evaluate_listing_eligibility(payload) == (False, expected_reason)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value", "expected_reason"),
+    [
+        ("model", "  GOLF   CART  ", "excluded model:   GOLF   CART  "),
+        ("make", "  OTHER  ", "excluded make:   OTHER  "),
+        ("status", "  CANCELED  ", "listing canceled"),
+    ],
+)
+def test_evaluate_listing_eligibility_normalizes_exact_excluded_values(
+    field_name, field_value, expected_reason
+):
+    if field_name == "status":
+        payload = _eligible_payload(status=field_value)
+    else:
+        payload = _eligible_payload(listing={field_name: field_value})
+
+    assert evaluate_listing_eligibility(payload) == (False, expected_reason)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    [
+        ("model", "customized"),
+        ("model", "golf cart trailer"),
+        ("make", "other manufacturer"),
+        ("make", "military vehicle parts"),
+    ],
+)
+def test_evaluate_listing_eligibility_allows_partial_excluded_values(
+    field_name, field_value
+):
+    payload = _eligible_payload(listing={field_name: field_value})
+
+    assert evaluate_listing_eligibility(payload) == (True, None)
+
+
+def test_evaluate_listing_eligibility_applies_rejection_order():
+    payload = _eligible_payload(
+        status="canceled",
+        listing={
+            "is_not_car": True,
+            "model": "Kart",
+            "make": "Other",
+            "year": 1945,
+        },
+    )
+
+    assert evaluate_listing_eligibility(payload) == (False, "listing marked not car")
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_reason"),
+    [
+        (
+            _eligible_payload(listing={"model": "Replica", "make": "Other"}),
+            "excluded model: Replica",
+        ),
+        (
+            _eligible_payload(
+                status="canceled",
+                listing={"make": "Other", "year": 1945},
+            ),
+            "excluded make: Other",
+        ),
+        (
+            _eligible_payload(status="canceled", listing={"year": "unknown"}),
+            "listing canceled",
+        ),
+    ],
+)
+def test_evaluate_listing_eligibility_applies_adjacent_rejection_order(
+    payload, expected_reason
+):
+    assert evaluate_listing_eligibility(payload) == (False, expected_reason)
+
+
+def test_evaluate_listing_eligibility_allows_truthy_non_boolean_is_not_car():
+    payload = _eligible_payload(listing={"is_not_car": "true"})
+
+    assert evaluate_listing_eligibility(payload) == (True, None)
 
 
 def test_fetch_listing_json_captures_matching_response(mocker, caplog):
@@ -167,6 +299,8 @@ def test_save_listing_json_executes_upsert_with_expected_conflict_target(
     assert upsert_params["source_site"] == "carsandbids"
     assert upsert_params["source_listing_id"] == "test-auction"
     assert upsert_params["url"] == "https://example.test/auctions/test-auction"
+    assert "eligible" not in upsert_params
+    assert "eligibility_reason" not in upsert_params
     assert isinstance(upsert_params["raw_json"], Jsonb)
     assert upsert_params["raw_json"].obj == payload
     assert marker_params == upsert_params


### PR DESCRIPTION
## Summary

- Add Cars & Bids `evaluate_listing_eligibility(payload)` for structured listing JSON.
- Reject non-car, excluded make/model, canceled, missing/non-numeric year, and pre-1946 listings in the approved order.
- Add focused unit coverage for the helper while keeping raw JSON ingest behavior unchanged.

## Verification

- `.venv\Scripts\python.exe -m pytest -q tests\unit\carsandbids\test_ingest.py`
- Result: `29 passed in 0.18s`

Closes #107.
