### PR TITLE
[codex] Add Cars and Bids pipeline orchestration

### DIFF
--- a/app/pipeline/carsandbids.py
+++ b/app/pipeline/carsandbids.py
@@ -1,0 +1,144 @@
+import logging
+from dataclasses import dataclass
+
+from app.sources.carsandbids.discovery import (
+    discover_completed_auctions,
+    load_pending_discovered_listings,
+    mark_discovered_listing_handled,
+)
+from app.sources.carsandbids.ingest import (
+    evaluate_listing_eligibility,
+    fetch_listing_json,
+    save_listing_json,
+)
+from app.sources.carsandbids.load import load_listing
+from app.sources.carsandbids.transform import (
+    load_pending_raw_listing_json,
+    transform_listing_json,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BatchIngestSummary:
+    selected: int = 0
+    scrape_attempted: int = 0
+    scrape_failed: int = 0
+    rejected: int = 0
+    raw_json_stored: int = 0
+    accepted: int = 0
+
+
+@dataclass
+class BatchTransformSummary:
+    selected: int = 0
+    transformed_and_loaded: int = 0
+    transform_failed: int = 0
+    load_failed: int = 0
+
+
+def ingest_listing(listing_id):
+    payload = fetch_listing_json(listing_id)
+    eligible, reason = evaluate_listing_eligibility(payload)
+    mark_discovered_listing_handled(listing_id, eligible, reason)
+
+    if not eligible:
+        return False
+
+    save_listing_json(listing_id, payload)
+    return True
+
+
+def transform_listing(listing_id):
+    transformed_listing = transform_listing_json(listing_id)
+    load_listing(transformed_listing)
+
+
+def run_listing(listing_id):
+    if not ingest_listing(listing_id):
+        return
+    transform_listing(listing_id)
+
+
+def discover_listings(scrape_date, max_candidates=None):
+    return discover_completed_auctions(
+        scrape_date=scrape_date,
+        max_candidates=max_candidates,
+    )
+
+
+def ingest_discovered_listings(batch_size=None):
+    summary = BatchIngestSummary()
+    pending_rows = load_pending_discovered_listings(limit=batch_size)
+
+    for row in pending_rows:
+        summary.selected += 1
+        listing_id = row["source_listing_id"]
+
+        summary.scrape_attempted += 1
+        try:
+            payload = fetch_listing_json(listing_id)
+        except Exception as exc:
+            summary.scrape_failed += 1
+            logger.error(
+                "carsandbids ingest-discovered scrape failed for listing_id=%s error=%s",
+                listing_id,
+                exc,
+            )
+            continue
+
+        eligible, reason = evaluate_listing_eligibility(payload)
+        mark_discovered_listing_handled(listing_id, eligible, reason)
+        if not eligible:
+            logger.info(
+                "carsandbids ingest-discovered listing rejected for listing_id=%s "
+                "reason=%s",
+                listing_id,
+                reason,
+            )
+            summary.rejected += 1
+            continue
+
+        save_listing_json(listing_id, payload, url=row["url"])
+        summary.raw_json_stored += 1
+        summary.accepted += 1
+
+    return summary
+
+
+def transform_discovered_listings(batch_size=None):
+    summary = BatchTransformSummary()
+    pending_rows = load_pending_raw_listing_json(limit=batch_size)
+
+    for row in pending_rows:
+        summary.selected += 1
+        listing_id = row["source_listing_id"]
+
+        try:
+            transformed_listing = transform_listing_json(listing_id)
+        except Exception as exc:
+            summary.transform_failed += 1
+            logger.error(
+                "carsandbids transform-discovered row failed for listing_id=%s "
+                "stage=transform error=%s",
+                listing_id,
+                exc,
+            )
+            continue
+
+        try:
+            load_listing(transformed_listing)
+        except Exception as exc:
+            summary.load_failed += 1
+            logger.error(
+                "carsandbids transform-discovered row failed for listing_id=%s "
+                "stage=load error=%s",
+                listing_id,
+                exc,
+            )
+            continue
+
+        summary.transformed_and_loaded += 1
+
+    return summary

--- a/app/sources/carsandbids/discovery.py
+++ b/app/sources/carsandbids/discovery.py
@@ -6,6 +6,7 @@ from urllib.parse import parse_qs, urlparse
 
 import psycopg
 from playwright.sync_api import sync_playwright
+from psycopg.rows import dict_row
 
 
 SOURCE_SITE = "carsandbids"
@@ -39,6 +40,33 @@ ON CONFLICT (source_site, source_listing_id) DO UPDATE SET
     auction_end_date = EXCLUDED.auction_end_date,
     last_seen_at = NOW()
 RETURNING xmax = 0 AS inserted
+"""
+
+SELECT_PENDING_DISCOVERED_LISTINGS_SQL = """
+SELECT
+    id,
+    source_site,
+    source_listing_id,
+    url,
+    title,
+    auction_end_date,
+    eligible,
+    eligibility_reason,
+    discovered_at,
+    last_seen_at,
+    ingested_at
+FROM discovered_listings
+WHERE source_site = %(source_site)s
+  AND eligible IS NULL
+ORDER BY discovered_at ASC, id ASC
+"""
+
+MARK_DISCOVERED_LISTING_HANDLED_SQL = """
+UPDATE discovered_listings
+SET eligible = %(eligible)s,
+    eligibility_reason = %(eligibility_reason)s
+WHERE source_site = %(source_site)s
+  AND source_listing_id = %(source_listing_id)s
 """
 
 
@@ -312,6 +340,45 @@ def save_discovered_listing(candidate):
                 params["source_listing_id"],
             )
             return inserted
+
+
+def load_pending_discovered_listings(limit=None):
+    if limit is not None and limit <= 0:
+        return []
+
+    database_url = _get_database_url()
+    params = {"source_site": SOURCE_SITE}
+    sql = SELECT_PENDING_DISCOVERED_LISTINGS_SQL
+
+    if limit is not None:
+        sql = f"{sql}\nLIMIT %(limit)s"
+        params["limit"] = limit
+
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(sql, params)
+            return cur.fetchall()
+
+
+def mark_discovered_listing_handled(listing_id, eligible, reason):
+    if eligible:
+        eligibility_reason = None
+    else:
+        if not reason or not str(reason).strip():
+            raise ValueError("reason is required when eligible is false")
+        eligibility_reason = reason
+
+    database_url = _get_database_url()
+    params = {
+        "source_site": SOURCE_SITE,
+        "source_listing_id": listing_id,
+        "eligible": eligible,
+        "eligibility_reason": eligibility_reason,
+    }
+
+    with psycopg.connect(database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(MARK_DISCOVERED_LISTING_HANDLED_SQL, params)
 
 
 def _get_database_url():

--- a/tests/unit/carsandbids/test_discovery.py
+++ b/tests/unit/carsandbids/test_discovery.py
@@ -634,6 +634,222 @@ def test_save_discovered_listing_requires_database_url(mocker):
         )
 
 
+def test_load_pending_discovered_listings_executes_pending_query(mocker):
+    calls = {"executions": [], "row_factory": None}
+    rows = [
+        {
+            "source_site": "carsandbids",
+            "source_listing_id": "3gNQk4RZ",
+            "url": "https://carsandbids.com/auctions/3gNQk4RZ",
+        }
+    ]
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            calls["executions"].append((sql, params))
+
+        def fetchall(self):
+            return rows
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self, row_factory=None):
+            calls["row_factory"] = row_factory
+            return FakeCursor()
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    connect = mocker.patch.object(
+        discovery.psycopg,
+        "connect",
+        return_value=FakeConnection(),
+    )
+
+    assert discovery.load_pending_discovered_listings(limit=5) == rows
+
+    connect.assert_called_once_with("postgresql://user:pass@localhost/db")
+    sql, params = calls["executions"][0]
+    assert "FROM discovered_listings" in sql
+    assert "WHERE source_site = %(source_site)s" in sql
+    assert "AND eligible IS NULL" in sql
+    assert "ORDER BY discovered_at ASC, id ASC" in sql
+    assert "LIMIT %(limit)s" in sql
+    assert params == {"source_site": "carsandbids", "limit": 5}
+    assert calls["row_factory"] is discovery.dict_row
+
+
+def test_load_pending_discovered_listings_omits_limit_when_not_requested(mocker):
+    calls = {"executions": []}
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            calls["executions"].append((sql, params))
+
+        def fetchall(self):
+            return []
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self, row_factory=None):
+            return FakeCursor()
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    mocker.patch.object(discovery.psycopg, "connect", return_value=FakeConnection())
+
+    assert discovery.load_pending_discovered_listings() == []
+
+    sql, params = calls["executions"][0]
+    assert "LIMIT %(limit)s" not in sql
+    assert params == {"source_site": "carsandbids"}
+
+
+def test_load_pending_discovered_listings_returns_empty_for_non_positive_limit(mocker):
+    mocker.patch.dict("os.environ", {}, clear=True)
+    connect = mocker.patch.object(discovery.psycopg, "connect")
+
+    assert discovery.load_pending_discovered_listings(limit=0) == []
+    assert discovery.load_pending_discovered_listings(limit=-1) == []
+    connect.assert_not_called()
+
+
+def test_load_pending_discovered_listings_requires_database_url(mocker):
+    mocker.patch.dict("os.environ", {}, clear=True)
+
+    with pytest.raises(RuntimeError, match="DATABASE_URL must be set"):
+        discovery.load_pending_discovered_listings()
+
+
+def test_mark_discovered_listing_handled_marks_eligible_and_clears_reason(mocker):
+    calls = {"executions": []}
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            calls["executions"].append((sql, params))
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    mocker.patch.object(discovery.psycopg, "connect", return_value=FakeConnection())
+
+    discovery.mark_discovered_listing_handled("3gNQk4RZ", True, "ignored")
+
+    sql, params = calls["executions"][0]
+    assert "UPDATE discovered_listings" in sql
+    assert "SET eligible = %(eligible)s" in sql
+    assert "eligibility_reason = %(eligibility_reason)s" in sql
+    assert "WHERE source_site = %(source_site)s" in sql
+    assert "AND source_listing_id = %(source_listing_id)s" in sql
+    assert params == {
+        "source_site": "carsandbids",
+        "source_listing_id": "3gNQk4RZ",
+        "eligible": True,
+        "eligibility_reason": None,
+    }
+
+
+def test_mark_discovered_listing_handled_marks_rejected_with_reason(mocker):
+    calls = {"executions": []}
+
+    class FakeCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, sql, params):
+            calls["executions"].append((sql, params))
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def cursor(self):
+            return FakeCursor()
+
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABASE_URL": "postgresql://user:pass@localhost/db"},
+    )
+    mocker.patch.object(discovery.psycopg, "connect", return_value=FakeConnection())
+
+    discovery.mark_discovered_listing_handled(
+        "3gNQk4RZ",
+        False,
+        "year before 1946",
+    )
+
+    _, params = calls["executions"][0]
+    assert params == {
+        "source_site": "carsandbids",
+        "source_listing_id": "3gNQk4RZ",
+        "eligible": False,
+        "eligibility_reason": "year before 1946",
+    }
+
+
+def test_mark_discovered_listing_handled_requires_rejection_reason():
+    with pytest.raises(ValueError, match="reason is required"):
+        discovery.mark_discovered_listing_handled("3gNQk4RZ", False, None)
+
+    with pytest.raises(ValueError, match="reason is required"):
+        discovery.mark_discovered_listing_handled("3gNQk4RZ", False, "   ")
+
+
+def test_mark_discovered_listing_handled_requires_database_url(mocker):
+    mocker.patch.dict("os.environ", {}, clear=True)
+
+    with pytest.raises(RuntimeError, match="DATABASE_URL must be set"):
+        discovery.mark_discovered_listing_handled("3gNQk4RZ", True, None)
+
+
 class FakeResponse:
     def __init__(
         self,

--- a/tests/unit/carsandbids/test_pipeline.py
+++ b/tests/unit/carsandbids/test_pipeline.py
@@ -1,0 +1,410 @@
+import logging
+from datetime import date
+
+from app.pipeline import carsandbids
+
+
+def test_ingest_listing_fetches_and_saves_listing_json(mocker):
+    payload = {"listing": {"year": 2004}}
+    fetch_listing_json = mocker.patch(
+        "app.pipeline.carsandbids.fetch_listing_json",
+        return_value=payload,
+    )
+    save_listing_json = mocker.patch("app.pipeline.carsandbids.save_listing_json")
+    evaluate_listing_eligibility = mocker.patch(
+        "app.pipeline.carsandbids.evaluate_listing_eligibility",
+        return_value=(True, None),
+    )
+    mark_discovered_listing_handled = mocker.patch(
+        "app.pipeline.carsandbids.mark_discovered_listing_handled"
+    )
+
+    assert carsandbids.ingest_listing("test-id") is True
+
+    fetch_listing_json.assert_called_once_with("test-id")
+    evaluate_listing_eligibility.assert_called_once_with(payload)
+    mark_discovered_listing_handled.assert_called_once_with("test-id", True, None)
+    save_listing_json.assert_called_once_with("test-id", payload)
+
+
+def test_ingest_listing_marks_rejected_listing_without_saving_json(mocker):
+    payload = {"listing": {"year": 1940}}
+    mocker.patch(
+        "app.pipeline.carsandbids.fetch_listing_json",
+        return_value=payload,
+    )
+    mocker.patch(
+        "app.pipeline.carsandbids.evaluate_listing_eligibility",
+        return_value=(False, "year before 1946"),
+    )
+    mark_discovered_listing_handled = mocker.patch(
+        "app.pipeline.carsandbids.mark_discovered_listing_handled"
+    )
+    save_listing_json = mocker.patch("app.pipeline.carsandbids.save_listing_json")
+
+    assert carsandbids.ingest_listing("test-id") is False
+
+    mark_discovered_listing_handled.assert_called_once_with(
+        "test-id",
+        False,
+        "year before 1946",
+    )
+    save_listing_json.assert_not_called()
+
+
+def test_transform_listing_transforms_and_loads_listing(mocker):
+    transformed_listing = {"listing_id": "test-id"}
+    transform_listing_json = mocker.patch(
+        "app.pipeline.carsandbids.transform_listing_json",
+        return_value=transformed_listing,
+    )
+    load_listing = mocker.patch("app.pipeline.carsandbids.load_listing")
+
+    carsandbids.transform_listing("test-id")
+
+    transform_listing_json.assert_called_once_with("test-id")
+    load_listing.assert_called_once_with(transformed_listing)
+
+
+def test_run_listing_executes_ingest_transform_load_in_order(mocker):
+    calls = []
+    payload = {"listing": {"year": 2004}}
+    transformed_listing = {"listing_id": "test-id"}
+
+    mocker.patch(
+        "app.pipeline.carsandbids.fetch_listing_json",
+        side_effect=lambda listing_id: calls.append(("fetch", listing_id)) or payload,
+    )
+    mocker.patch(
+        "app.pipeline.carsandbids.save_listing_json",
+        side_effect=lambda listing_id, listing_json: calls.append(
+            ("save", listing_id, listing_json)
+        ),
+    )
+    mocker.patch(
+        "app.pipeline.carsandbids.evaluate_listing_eligibility",
+        side_effect=lambda listing_json: calls.append(("evaluate", listing_json))
+        or (True, None),
+    )
+    mocker.patch(
+        "app.pipeline.carsandbids.mark_discovered_listing_handled",
+        side_effect=lambda listing_id, eligible, reason: calls.append(
+            ("mark_handled", listing_id, eligible, reason)
+        ),
+    )
+    mocker.patch(
+        "app.pipeline.carsandbids.transform_listing_json",
+        side_effect=lambda listing_id: calls.append(("transform", listing_id))
+        or transformed_listing,
+    )
+    mocker.patch(
+        "app.pipeline.carsandbids.load_listing",
+        side_effect=lambda listing: calls.append(("load", listing)),
+    )
+
+    carsandbids.run_listing("test-id")
+
+    assert calls == [
+        ("fetch", "test-id"),
+        ("evaluate", payload),
+        ("mark_handled", "test-id", True, None),
+        ("save", "test-id", payload),
+        ("transform", "test-id"),
+        ("load", transformed_listing),
+    ]
+
+
+def test_run_listing_skips_transform_when_ingest_rejects_listing(mocker):
+    mocker.patch("app.pipeline.carsandbids.ingest_listing", return_value=False)
+    transform_listing = mocker.patch("app.pipeline.carsandbids.transform_listing")
+
+    carsandbids.run_listing("test-id")
+
+    transform_listing.assert_not_called()
+
+
+def test_discover_listings_delegates_to_discovery(mocker):
+    discover_completed_auctions = mocker.patch(
+        "app.pipeline.carsandbids.discover_completed_auctions"
+    )
+
+    carsandbids.discover_listings(scrape_date=date(2026, 4, 20), max_candidates=5)
+
+    discover_completed_auctions.assert_called_once_with(
+        scrape_date=date(2026, 4, 20),
+        max_candidates=5,
+    )
+
+
+def test_ingest_discovered_listings_returns_zeroed_summary_for_empty_batch(mocker):
+    mocker.patch(
+        "app.pipeline.carsandbids.load_pending_discovered_listings",
+        return_value=[],
+    )
+
+    summary = carsandbids.ingest_discovered_listings()
+
+    assert summary == carsandbids.BatchIngestSummary()
+
+
+def test_transform_discovered_listings_returns_zeroed_summary_for_empty_batch(mocker):
+    mocker.patch(
+        "app.pipeline.carsandbids.load_pending_raw_listing_json",
+        return_value=[],
+    )
+
+    summary = carsandbids.transform_discovered_listings()
+
+    assert summary == carsandbids.BatchTransformSummary()
+
+
+def test_ingest_discovered_listings_marks_reject_without_saving_json(mocker, caplog):
+    payload = {"listing": {"year": 1940}}
+    mocker.patch(
+        "app.pipeline.carsandbids.load_pending_discovered_listings",
+        return_value=[
+            {
+                "source_listing_id": "rejected",
+                "title": "1940 Ford Coupe",
+                "url": "https://carsandbids.com/auctions/rejected",
+            }
+        ],
+    )
+    mocker.patch("app.pipeline.carsandbids.fetch_listing_json", return_value=payload)
+    evaluate_listing_eligibility = mocker.patch(
+        "app.pipeline.carsandbids.evaluate_listing_eligibility",
+        return_value=(False, "year before 1946"),
+    )
+    mark_handled = mocker.patch(
+        "app.pipeline.carsandbids.mark_discovered_listing_handled"
+    )
+    save_listing_json = mocker.patch("app.pipeline.carsandbids.save_listing_json")
+
+    caplog.set_level(logging.INFO)
+    summary = carsandbids.ingest_discovered_listings()
+
+    evaluate_listing_eligibility.assert_called_once_with(payload)
+    mark_handled.assert_called_once_with("rejected", False, "year before 1946")
+    save_listing_json.assert_not_called()
+    assert (
+        "carsandbids ingest-discovered listing rejected for listing_id=rejected "
+        "reason=year before 1946"
+    ) in caplog.text
+    assert summary == carsandbids.BatchIngestSummary(
+        selected=1,
+        scrape_attempted=1,
+        rejected=1,
+    )
+
+
+def test_ingest_discovered_listings_records_scrape_failure_without_marking_row(mocker):
+    mocker.patch(
+        "app.pipeline.carsandbids.load_pending_discovered_listings",
+        return_value=[
+            {
+                "source_listing_id": "scrape-fail",
+                "title": "2004 BMW M3 Coupe",
+                "url": "https://carsandbids.com/auctions/scrape-fail",
+            }
+        ],
+    )
+    mocker.patch(
+        "app.pipeline.carsandbids.fetch_listing_json",
+        side_effect=RuntimeError("network failed"),
+    )
+    mark_handled = mocker.patch(
+        "app.pipeline.carsandbids.mark_discovered_listing_handled"
+    )
+
+    summary = carsandbids.ingest_discovered_listings()
+
+    mark_handled.assert_not_called()
+    assert summary == carsandbids.BatchIngestSummary(
+        selected=1,
+        scrape_attempted=1,
+        scrape_failed=1,
+    )
+
+
+def test_ingest_discovered_listings_saves_json_and_marks_eligible_for_pass(mocker):
+    payload = {"listing": {"year": 2004}}
+    mocker.patch(
+        "app.pipeline.carsandbids.load_pending_discovered_listings",
+        return_value=[
+            {
+                "source_listing_id": "accepted",
+                "title": "2004 BMW M3 Coupe",
+                "url": "https://carsandbids.com/auctions/accepted",
+            }
+        ],
+    )
+    mocker.patch("app.pipeline.carsandbids.fetch_listing_json", return_value=payload)
+    mocker.patch(
+        "app.pipeline.carsandbids.evaluate_listing_eligibility",
+        return_value=(True, None),
+    )
+    save_listing_json = mocker.patch("app.pipeline.carsandbids.save_listing_json")
+    mark_handled = mocker.patch(
+        "app.pipeline.carsandbids.mark_discovered_listing_handled"
+    )
+    calls = mocker.Mock()
+    calls.attach_mock(save_listing_json, "save_listing_json")
+    calls.attach_mock(mark_handled, "mark_handled")
+
+    summary = carsandbids.ingest_discovered_listings()
+
+    save_listing_json.assert_called_once_with(
+        "accepted",
+        payload,
+        url="https://carsandbids.com/auctions/accepted",
+    )
+    mark_handled.assert_called_once_with("accepted", True, None)
+    assert calls.mock_calls == [
+        mocker.call.mark_handled("accepted", True, None),
+        mocker.call.save_listing_json(
+            "accepted",
+            payload,
+            url="https://carsandbids.com/auctions/accepted",
+        ),
+    ]
+    assert summary == carsandbids.BatchIngestSummary(
+        selected=1,
+        scrape_attempted=1,
+        raw_json_stored=1,
+        accepted=1,
+    )
+
+
+def test_ingest_discovered_listings_handles_mixed_batch_outcomes(mocker):
+    accepted_payload = {"listing": {"year": 2004}}
+    mocker.patch(
+        "app.pipeline.carsandbids.load_pending_discovered_listings",
+        return_value=[
+            {
+                "source_listing_id": "year-reject",
+                "title": "1940 Ford Coupe",
+                "url": "https://carsandbids.com/auctions/year-reject",
+            },
+            {
+                "source_listing_id": "scrape-fail",
+                "title": "2004 BMW M3 Coupe",
+                "url": "https://carsandbids.com/auctions/scrape-fail",
+            },
+            {
+                "source_listing_id": "model-reject",
+                "title": "Custom Kart",
+                "url": "https://carsandbids.com/auctions/model-reject",
+            },
+            {
+                "source_listing_id": "accepted",
+                "title": "2004 BMW M3 Coupe",
+                "url": "https://carsandbids.com/auctions/accepted",
+            },
+        ],
+    )
+    mocker.patch(
+        "app.pipeline.carsandbids.fetch_listing_json",
+        side_effect=[
+            {"listing": {"year": 1940}},
+            RuntimeError("network failed"),
+            {"listing": {"model": "Kart"}},
+            accepted_payload,
+        ],
+    )
+    mocker.patch(
+        "app.pipeline.carsandbids.evaluate_listing_eligibility",
+        side_effect=[
+            (False, "year before 1946"),
+            (False, "excluded model: Kart"),
+            (True, None),
+        ],
+    )
+    save_listing_json = mocker.patch("app.pipeline.carsandbids.save_listing_json")
+    mark_handled = mocker.patch(
+        "app.pipeline.carsandbids.mark_discovered_listing_handled"
+    )
+    calls = mocker.Mock()
+    calls.attach_mock(save_listing_json, "save_listing_json")
+    calls.attach_mock(mark_handled, "mark_handled")
+
+    summary = carsandbids.ingest_discovered_listings()
+
+    assert summary == carsandbids.BatchIngestSummary(
+        selected=4,
+        scrape_attempted=4,
+        scrape_failed=1,
+        rejected=2,
+        raw_json_stored=1,
+        accepted=1,
+    )
+    assert mark_handled.call_args_list == [
+        mocker.call("year-reject", False, "year before 1946"),
+        mocker.call("model-reject", False, "excluded model: Kart"),
+        mocker.call("accepted", True, None),
+    ]
+    save_listing_json.assert_called_once_with(
+        "accepted",
+        accepted_payload,
+        url="https://carsandbids.com/auctions/accepted",
+    )
+    assert calls.mock_calls[-2:] == [
+        mocker.call.mark_handled("accepted", True, None),
+        mocker.call.save_listing_json(
+            "accepted",
+            accepted_payload,
+            url="https://carsandbids.com/auctions/accepted",
+        ),
+    ]
+
+
+def test_transform_discovered_listings_handles_mixed_batch_outcomes(mocker, caplog):
+    mocker.patch(
+        "app.pipeline.carsandbids.load_pending_raw_listing_json",
+        return_value=[
+            {"source_listing_id": "transform-fail"},
+            {"source_listing_id": "load-fail"},
+            {"source_listing_id": "success"},
+        ],
+    )
+    transformed_load_fail = {"listing_id": "load-fail"}
+    transformed_success = {"listing_id": "success"}
+    mocker.patch(
+        "app.pipeline.carsandbids.transform_listing_json",
+        side_effect=[
+            RuntimeError("missing raw json"),
+            transformed_load_fail,
+            transformed_success,
+        ],
+    )
+    load_listing = mocker.patch(
+        "app.pipeline.carsandbids.load_listing",
+        side_effect=[
+            RuntimeError("constraint violation"),
+            None,
+        ],
+    )
+
+    caplog.set_level(logging.ERROR)
+    summary = carsandbids.transform_discovered_listings(batch_size=3)
+
+    load_listing.assert_has_calls(
+        [
+            mocker.call(transformed_load_fail),
+            mocker.call(transformed_success),
+        ]
+    )
+    assert summary == carsandbids.BatchTransformSummary(
+        selected=3,
+        transformed_and_loaded=1,
+        transform_failed=1,
+        load_failed=1,
+    )
+    assert (
+        "carsandbids transform-discovered row failed for listing_id=transform-fail "
+        "stage=transform error=missing raw json"
+    ) in caplog.text
+    assert (
+        "carsandbids transform-discovered row failed for listing_id=load-fail "
+        "stage=load error=constraint violation"
+    ) in caplog.text
+    assert "Traceback" not in caplog.text


### PR DESCRIPTION
## Summary

Adds Cars and Bids pipeline orchestration for issue #110, mirroring the existing BAT pipeline while using the Cars and Bids JSON ingest, transform, and load primitives.

## Changes

- Added `app/pipeline/carsandbids.py` with single-listing and discovered-listing orchestration.
- Added Cars and Bids discovery helpers for pending discovered rows and handled eligibility state.
- Added focused unit tests for pipeline orchestration and the new discovery helper SQL behavior.

## Validation

- `.venv\Scripts\python.exe -m pytest -q tests\unit\carsandbids\test_pipeline.py tests\unit\carsandbids\test_discovery.py tests\unit\carsandbids tests\unit\bat\test_pipeline.py`
  - `114 passed in 0.52s`

Closes #110