### PR TITLE
[codex] Add Cars and Bids CLI

### DIFF
--- a/app/sources/carsandbids/cli.py
+++ b/app/sources/carsandbids/cli.py
@@ -1,0 +1,181 @@
+import argparse
+import logging
+from datetime import date
+
+from dotenv import load_dotenv
+
+from app.pipeline import carsandbids as carsandbids_pipeline
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description="Run Cars and Bids ETL commands.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for command in ("ingest", "transform", "run"):
+        subparser = subparsers.add_parser(command)
+        subparser.add_argument("--listing-id", required=True)
+
+    discover_parser = subparsers.add_parser("discover")
+    discover_parser.add_argument(
+        "--scrape-date",
+        type=date.fromisoformat,
+        default=date.today(),
+    )
+    discover_parser.add_argument("--max-candidates", type=int)
+
+    ingest_discovered_parser = subparsers.add_parser("ingest-discovered")
+    ingest_discovered_parser.add_argument("--batch-size", type=int)
+
+    transform_discovered_parser = subparsers.add_parser("transform-discovered")
+    transform_discovered_parser.add_argument("--batch-size", type=int)
+
+    return parser
+
+
+def configure_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s %(name)s %(message)s",
+    )
+
+
+def main(argv=None):
+    configure_logging()
+    args = build_parser().parse_args(argv)
+
+    try:
+        if args.command == "discover":
+            logger.info(
+                "carsandbids discover command started for scrape_date=%s max_candidates=%s",
+                args.scrape_date.isoformat(),
+                args.max_candidates,
+            )
+            summary = carsandbids_pipeline.discover_listings(
+                scrape_date=args.scrape_date,
+                max_candidates=args.max_candidates,
+            )
+            logger.info(
+                "carsandbids discover summary inspected=%s new=%s existing_or_updated=%s failed=%s",
+                summary.candidates_inspected,
+                summary.newly_discovered,
+                summary.already_discovered_or_updated,
+                summary.failed,
+            )
+            print(
+                "Discovery summary: "
+                f"inspected={summary.candidates_inspected} "
+                f"new={summary.newly_discovered} "
+                f"existing_or_updated={summary.already_discovered_or_updated} "
+                f"failed={summary.failed}"
+            )
+            logger.info(
+                "carsandbids discover command completed for scrape_date=%s",
+                args.scrape_date.isoformat(),
+            )
+            return
+        if args.command == "ingest-discovered":
+            logger.info(
+                "carsandbids ingest-discovered command started for batch_size=%s",
+                args.batch_size,
+            )
+            summary = carsandbids_pipeline.ingest_discovered_listings(
+                batch_size=args.batch_size
+            )
+            logger.info(
+                "carsandbids ingest-discovered summary selected=%s scrape_attempted=%s scrape_failed=%s rejected=%s raw_json_stored=%s accepted=%s",
+                summary.selected,
+                summary.scrape_attempted,
+                summary.scrape_failed,
+                summary.rejected,
+                summary.raw_json_stored,
+                summary.accepted,
+            )
+            print(
+                "Ingest-discovered summary: "
+                f"selected={summary.selected} "
+                f"scrape_attempted={summary.scrape_attempted} "
+                f"scrape_failed={summary.scrape_failed} "
+                f"rejected={summary.rejected} "
+                f"raw_json_stored={summary.raw_json_stored} "
+                f"accepted={summary.accepted}"
+            )
+            logger.info(
+                "carsandbids ingest-discovered command completed for batch_size=%s",
+                args.batch_size,
+            )
+            return
+        if args.command == "transform-discovered":
+            logger.info(
+                "carsandbids transform-discovered command started for batch_size=%s",
+                args.batch_size,
+            )
+            summary = carsandbids_pipeline.transform_discovered_listings(
+                batch_size=args.batch_size
+            )
+            logger.info(
+                "carsandbids transform-discovered summary selected=%s transformed_and_loaded=%s transform_failed=%s load_failed=%s",
+                summary.selected,
+                summary.transformed_and_loaded,
+                summary.transform_failed,
+                summary.load_failed,
+            )
+            print(
+                "Transform-discovered summary: "
+                f"selected={summary.selected} "
+                f"transformed_and_loaded={summary.transformed_and_loaded} "
+                f"transform_failed={summary.transform_failed} "
+                f"load_failed={summary.load_failed}"
+            )
+            logger.info(
+                "carsandbids transform-discovered command completed for batch_size=%s",
+                args.batch_size,
+            )
+            return
+
+        logger.info(
+            "carsandbids %s command started for listing_id=%s",
+            args.command,
+            args.listing_id,
+        )
+        if args.command == "ingest":
+            carsandbids_pipeline.ingest_listing(args.listing_id)
+        elif args.command == "transform":
+            carsandbids_pipeline.transform_listing(args.listing_id)
+        elif args.command == "run":
+            carsandbids_pipeline.run_listing(args.listing_id)
+    except Exception:
+        if args.command == "discover":
+            logger.error(
+                "carsandbids discover command failed for scrape_date=%s",
+                args.scrape_date.isoformat(),
+            )
+        elif args.command == "ingest-discovered":
+            logger.error(
+                "carsandbids ingest-discovered command failed for batch_size=%s",
+                args.batch_size,
+            )
+        elif args.command == "transform-discovered":
+            logger.error(
+                "carsandbids transform-discovered command failed for batch_size=%s",
+                args.batch_size,
+            )
+        else:
+            logger.error(
+                "carsandbids %s command failed for listing_id=%s",
+                args.command,
+                args.listing_id,
+            )
+        raise
+    logger.info(
+        "carsandbids %s command completed for listing_id=%s",
+        args.command,
+        args.listing_id,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/carsandbids/test_cli.py
+++ b/tests/unit/carsandbids/test_cli.py
@@ -1,0 +1,277 @@
+import logging
+from datetime import date
+
+import pytest
+
+from app.pipeline import carsandbids
+from app.sources.carsandbids import cli
+
+
+def test_ingest_command_fetches_and_saves_listing_json(mocker, caplog):
+    ingest_listing = mocker.patch(
+        "app.sources.carsandbids.cli.carsandbids_pipeline.ingest_listing"
+    )
+
+    caplog.set_level(logging.INFO)
+    cli.main(["ingest", "--listing-id", "test-id"])
+
+    ingest_listing.assert_called_once_with("test-id")
+    assert "carsandbids ingest command started for listing_id=test-id" in caplog.text
+    assert "carsandbids ingest command completed for listing_id=test-id" in caplog.text
+
+
+def test_transform_command_logs_failure_context_without_traceback_and_reraises(
+    mocker, caplog
+):
+    error = RuntimeError("transform failed")
+    mocker.patch(
+        "app.sources.carsandbids.cli.carsandbids_pipeline.transform_listing",
+        side_effect=error,
+    )
+
+    caplog.set_level(logging.INFO)
+    with pytest.raises(RuntimeError) as exc_info:
+        cli.main(["transform", "--listing-id", "test-id"])
+
+    assert exc_info.value is error
+    assert "carsandbids transform command started for listing_id=test-id" in caplog.text
+    assert "carsandbids transform command failed for listing_id=test-id" in caplog.text
+    assert "Traceback" not in caplog.text
+    assert "RuntimeError: transform failed" not in caplog.text
+
+
+def test_run_command_executes_ingest_transform_load_in_order(mocker):
+    run_listing = mocker.patch(
+        "app.sources.carsandbids.cli.carsandbids_pipeline.run_listing"
+    )
+
+    cli.main(["run", "--listing-id", "test-id"])
+
+    run_listing.assert_called_once_with("test-id")
+
+
+def test_discover_command_parses_without_listing_id():
+    args = cli.build_parser().parse_args(["discover"])
+
+    assert args.command == "discover"
+    assert args.max_candidates is None
+    assert isinstance(args.scrape_date, date)
+
+
+def test_discover_command_dispatches_with_parsed_options(mocker, caplog, capsys):
+    discover_listings = mocker.patch(
+        "app.sources.carsandbids.cli.carsandbids_pipeline.discover_listings",
+        return_value=mocker.Mock(
+            candidates_inspected=2,
+            newly_discovered=1,
+            already_discovered_or_updated=1,
+            failed=0,
+        ),
+    )
+
+    caplog.set_level(logging.INFO)
+    cli.main(
+        [
+            "discover",
+            "--scrape-date",
+            "2026-04-20",
+            "--max-candidates",
+            "5",
+        ]
+    )
+
+    discover_listings.assert_called_once_with(
+        scrape_date=date(2026, 4, 20),
+        max_candidates=5,
+    )
+    assert (
+        "carsandbids discover command started for scrape_date=2026-04-20 max_candidates=5"
+    ) in caplog.text
+    assert (
+        "carsandbids discover summary inspected=2 new=1 existing_or_updated=1 failed=0"
+    ) in caplog.text
+    assert "carsandbids discover command completed for scrape_date=2026-04-20" in caplog.text
+    assert (
+        "Discovery summary: inspected=2 new=1 existing_or_updated=1 failed=0"
+        in capsys.readouterr().out
+    )
+
+
+def test_discover_command_logs_failure_context_without_traceback_and_reraises(
+    mocker, caplog
+):
+    error = RuntimeError("discover failed")
+    mocker.patch(
+        "app.sources.carsandbids.cli.carsandbids_pipeline.discover_listings",
+        side_effect=error,
+    )
+
+    caplog.set_level(logging.INFO)
+    with pytest.raises(RuntimeError) as exc_info:
+        cli.main(["discover", "--scrape-date", "2026-04-20"])
+
+    assert exc_info.value is error
+    assert (
+        "carsandbids discover command started for scrape_date=2026-04-20 max_candidates=None"
+        in caplog.text
+    )
+    assert "carsandbids discover command failed for scrape_date=2026-04-20" in caplog.text
+    assert "Traceback" not in caplog.text
+    assert "RuntimeError: discover failed" not in caplog.text
+
+
+def test_discover_command_rejects_results_url_option(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["discover", "--results-url", "https://carsandbids.com/past-auctions/"])
+
+    assert exc_info.value.code == 2
+    assert "--results-url" in capsys.readouterr().err
+
+
+def test_ingest_discovered_command_parses_without_batch_size():
+    args = cli.build_parser().parse_args(["ingest-discovered"])
+
+    assert args.command == "ingest-discovered"
+    assert args.batch_size is None
+
+
+def test_ingest_discovered_command_parses_with_batch_size():
+    args = cli.build_parser().parse_args(["ingest-discovered", "--batch-size", "5"])
+
+    assert args.command == "ingest-discovered"
+    assert args.batch_size == 5
+
+
+def test_transform_discovered_command_parses_without_batch_size():
+    args = cli.build_parser().parse_args(["transform-discovered"])
+
+    assert args.command == "transform-discovered"
+    assert args.batch_size is None
+
+
+def test_transform_discovered_command_parses_with_batch_size():
+    args = cli.build_parser().parse_args(["transform-discovered", "--batch-size", "5"])
+
+    assert args.command == "transform-discovered"
+    assert args.batch_size == 5
+
+
+def test_ingest_discovered_command_dispatches_with_parsed_options(
+    mocker, caplog, capsys
+):
+    ingest_discovered_listings = mocker.patch(
+        "app.sources.carsandbids.cli.carsandbids_pipeline.ingest_discovered_listings",
+        return_value=carsandbids.BatchIngestSummary(
+            selected=3,
+            scrape_attempted=2,
+            scrape_failed=1,
+            rejected=1,
+            raw_json_stored=1,
+            accepted=1,
+        ),
+    )
+
+    caplog.set_level(logging.INFO)
+    cli.main(["ingest-discovered", "--batch-size", "5"])
+
+    ingest_discovered_listings.assert_called_once_with(batch_size=5)
+    assert "carsandbids ingest-discovered command started for batch_size=5" in caplog.text
+    assert (
+        "carsandbids ingest-discovered summary selected=3 scrape_attempted=2 "
+        "scrape_failed=1 rejected=1 raw_json_stored=1 accepted=1"
+    ) in caplog.text
+    assert "carsandbids ingest-discovered command completed for batch_size=5" in caplog.text
+    assert (
+        "Ingest-discovered summary: selected=3 scrape_attempted=2 "
+        "scrape_failed=1 rejected=1 raw_json_stored=1 accepted=1"
+    ) in capsys.readouterr().out
+
+
+def test_ingest_discovered_command_logs_failure_context_without_traceback_and_reraises(
+    mocker, caplog
+):
+    error = RuntimeError("ingest-discovered failed")
+    mocker.patch(
+        "app.sources.carsandbids.cli.carsandbids_pipeline.ingest_discovered_listings",
+        side_effect=error,
+    )
+
+    caplog.set_level(logging.INFO)
+    with pytest.raises(RuntimeError) as exc_info:
+        cli.main(["ingest-discovered", "--batch-size", "5"])
+
+    assert exc_info.value is error
+    assert "carsandbids ingest-discovered command started for batch_size=5" in caplog.text
+    assert "carsandbids ingest-discovered command failed for batch_size=5" in caplog.text
+    assert "Traceback" not in caplog.text
+    assert "RuntimeError: ingest-discovered failed" not in caplog.text
+
+
+def test_transform_discovered_command_dispatches_with_parsed_options(
+    mocker, caplog, capsys
+):
+    transform_discovered_listings = mocker.patch(
+        "app.sources.carsandbids.cli.carsandbids_pipeline.transform_discovered_listings",
+        return_value=carsandbids.BatchTransformSummary(
+            selected=3,
+            transformed_and_loaded=1,
+            transform_failed=1,
+            load_failed=1,
+        ),
+    )
+
+    caplog.set_level(logging.INFO)
+    cli.main(["transform-discovered", "--batch-size", "5"])
+
+    transform_discovered_listings.assert_called_once_with(batch_size=5)
+    assert (
+        "carsandbids transform-discovered command started for batch_size=5"
+        in caplog.text
+    )
+    assert (
+        "carsandbids transform-discovered summary selected=3 transformed_and_loaded=1 "
+        "transform_failed=1 load_failed=1"
+    ) in caplog.text
+    assert (
+        "carsandbids transform-discovered command completed for batch_size=5"
+        in caplog.text
+    )
+    assert (
+        "Transform-discovered summary: selected=3 transformed_and_loaded=1 "
+        "transform_failed=1 load_failed=1"
+    ) in capsys.readouterr().out
+
+
+def test_transform_discovered_command_logs_failure_context_without_traceback_and_reraises(
+    mocker, caplog
+):
+    error = RuntimeError("transform-discovered failed")
+    mocker.patch(
+        "app.sources.carsandbids.cli.carsandbids_pipeline.transform_discovered_listings",
+        side_effect=error,
+    )
+
+    caplog.set_level(logging.INFO)
+    with pytest.raises(RuntimeError) as exc_info:
+        cli.main(["transform-discovered", "--batch-size", "5"])
+
+    assert exc_info.value is error
+    assert (
+        "carsandbids transform-discovered command started for batch_size=5"
+        in caplog.text
+    )
+    assert (
+        "carsandbids transform-discovered command failed for batch_size=5"
+        in caplog.text
+    )
+    assert "Traceback" not in caplog.text
+    assert "RuntimeError: transform-discovered failed" not in caplog.text
+
+
+@pytest.mark.parametrize("command", ["ingest", "transform", "run"])
+def test_commands_require_listing_id(command, capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main([command])
+
+    assert exc_info.value.code == 2
+    assert "--listing-id" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- Add `app.sources.carsandbids.cli` mirroring the BAT CLI command surface.
- Dispatch Cars and Bids commands through `app.pipeline.carsandbids`.
- Add Cars and Bids CLI unit coverage matching the BAT CLI behavior, including `raw_json_stored` batch ingest summaries.

## Validation

- `.venv\Scripts\python.exe -m pytest -q tests\unit\carsandbids\test_cli.py`
- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_cli.py tests\unit\carsandbids\test_cli.py`

Closes #112