### PR TITLE
[codex] Add Cars and Bids browser context helper

### DIFF
--- a/app/sources/carsandbids/browser.py
+++ b/app/sources/carsandbids/browser.py
@@ -1,0 +1,11 @@
+CARSANDBIDS_CHROME_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/145.0.0.0 Safari/537.36"
+)
+
+
+def launch_carsandbids_browser_context(playwright, headless=True):
+    browser = playwright.chromium.launch(headless=headless)
+    context = browser.new_context(user_agent=CARSANDBIDS_CHROME_USER_AGENT)
+    return browser, context

--- a/app/sources/carsandbids/discovery.py
+++ b/app/sources/carsandbids/discovery.py
@@ -8,6 +8,8 @@ import psycopg
 from playwright.sync_api import sync_playwright
 from psycopg.rows import dict_row
 
+from app.sources.carsandbids.browser import launch_carsandbids_browser_context
+
 
 SOURCE_SITE = "carsandbids"
 PAST_AUCTIONS_URL = "https://carsandbids.com/past-auctions/"
@@ -81,9 +83,9 @@ class DiscoverySummary:
 def capture_initial_completed_auctions_page(headless=True):
     logger.info("Capturing initial Cars and Bids completed auctions page")
     with sync_playwright() as playwright:
-        browser = playwright.chromium.launch(headless=headless)
+        browser, context = launch_carsandbids_browser_context(playwright, headless)
         try:
-            page = browser.new_page()
+            page = context.new_page()
             payload, timestamp, signature = _capture_initial_completed_auctions_page(
                 page
             )
@@ -200,9 +202,9 @@ def discover_completed_auctions(scrape_date, max_candidates=None, headless=True)
     summary = DiscoverySummary()
 
     with sync_playwright() as playwright:
-        browser = playwright.chromium.launch(headless=headless)
+        browser, context = launch_carsandbids_browser_context(playwright, headless)
         try:
-            page = browser.new_page()
+            page = context.new_page()
             payload, timestamp, signature = _capture_initial_completed_auctions_page(
                 page
             )

--- a/app/sources/carsandbids/ingest.py
+++ b/app/sources/carsandbids/ingest.py
@@ -5,6 +5,8 @@ import psycopg
 from playwright.sync_api import sync_playwright
 from psycopg.types.json import Jsonb
 
+from app.sources.carsandbids.browser import launch_carsandbids_browser_context
+
 
 SOURCE_SITE = "carsandbids"
 LISTING_URL_BASE = "https://carsandbids.com/auctions"
@@ -63,9 +65,9 @@ def fetch_listing_json(listing_id):
 
     logger.info("Fetching Cars and Bids listing JSON for listing_id=%s", listing_id)
     with sync_playwright() as playwright:
-        browser = playwright.chromium.launch(headless=True)
+        browser, context = launch_carsandbids_browser_context(playwright, headless=True)
         try:
-            page = browser.new_page()
+            page = context.new_page()
             page.on("response", capture_matching_response)
             page.goto(
                 listing_url,

--- a/tests/unit/carsandbids/test_discovery.py
+++ b/tests/unit/carsandbids/test_discovery.py
@@ -5,6 +5,7 @@ from datetime import date
 import pytest
 
 from app.sources.carsandbids import discovery
+from app.sources.carsandbids.browser import CARSANDBIDS_CHROME_USER_AGENT
 
 
 def test_normalize_completed_auction_candidate_maps_endpoint_auction():
@@ -84,8 +85,33 @@ def test_capture_initial_completed_auctions_page_captures_signed_response(
         ("https://carsandbids.com/past-auctions/", "domcontentloaded", 60000)
     ]
     assert playwright.chromium.launch_calls == [{"headless": True}]
+    assert playwright.chromium.browser.new_context_calls == [
+        {"user_agent": CARSANDBIDS_CHROME_USER_AGENT}
+    ]
+    assert playwright.chromium.browser.context.new_page_calls == 1
     assert "Capturing initial Cars and Bids completed auctions page" in caplog.text
     assert "Captured initial Cars and Bids completed auctions page" in caplog.text
+
+
+def test_capture_initial_completed_auctions_page_preserves_headed_launch(mocker):
+    response = FakeResponse(
+        "https://carsandbids.com/v2/autos/auctions?status=closed"
+        "&timestamp=ts&signature=sig",
+        payload={"auctions": []},
+    )
+    page = FakePage([response])
+    playwright = FakePlaywright(page)
+    mocker.patch.object(
+        discovery, "sync_playwright", return_value=FakePlaywrightContext(playwright)
+    )
+
+    discovery.capture_initial_completed_auctions_page(headless=False)
+
+    assert playwright.chromium.launch_calls == [{"headless": False}]
+    assert playwright.chromium.browser.new_context_calls == [
+        {"user_agent": CARSANDBIDS_CHROME_USER_AGENT}
+    ]
+    assert playwright.chromium.browser.context.new_page_calls == 1
 
 
 def test_capture_initial_completed_auctions_page_waits_for_late_matching_response(
@@ -97,10 +123,11 @@ def test_capture_initial_completed_auctions_page_waits_for_late_matching_respons
         payload={"auctions": []},
     )
     page = FakePage([], wait_response=matching_response)
+    playwright = FakePlaywright(page)
     mocker.patch.object(
         discovery,
         "sync_playwright",
-        return_value=FakePlaywrightContext(FakePlaywright(page)),
+        return_value=FakePlaywrightContext(playwright),
     )
 
     payload, timestamp, signature = discovery.capture_initial_completed_auctions_page()
@@ -122,10 +149,11 @@ def test_capture_initial_completed_auctions_page_raises_when_response_is_absent(
             )
         ]
     )
+    playwright = FakePlaywright(page)
     mocker.patch.object(
         discovery,
         "sync_playwright",
-        return_value=FakePlaywrightContext(FakePlaywright(page)),
+        return_value=FakePlaywrightContext(playwright),
     )
 
     with pytest.raises(RuntimeError, match="API response not found"):
@@ -303,10 +331,11 @@ def test_discover_completed_auctions_uses_page_fetch_for_followups(mocker):
         ],
         evaluate_responses=[{"ok": True, "status": 200, "text": _json({"auctions": []})}],
     )
+    playwright = FakePlaywright(page)
     mocker.patch.object(
         discovery,
         "sync_playwright",
-        return_value=FakePlaywrightContext(FakePlaywright(page)),
+        return_value=FakePlaywrightContext(playwright),
     )
     mocker.patch(
         "app.sources.carsandbids.discovery.save_discovered_listing",
@@ -315,6 +344,11 @@ def test_discover_completed_auctions_uses_page_fetch_for_followups(mocker):
 
     discovery.discover_completed_auctions(scrape_date="2026-04-20")
 
+    assert playwright.chromium.launch_calls == [{"headless": True}]
+    assert playwright.chromium.browser.new_context_calls == [
+        {"user_agent": CARSANDBIDS_CHROME_USER_AGENT}
+    ]
+    assert playwright.chromium.browser.context.new_page_calls == 1
     assert page.evaluate_call_args == [
         {
             "url": "https://carsandbids.com/v2/autos/auctions",
@@ -914,13 +948,26 @@ class FakePage:
 class FakeBrowser:
     def __init__(self, page):
         self.page = page
+        self.context = FakeBrowserContext(page)
+        self.new_context_calls = []
         self.closed = False
 
-    def new_page(self):
-        return self.page
+    def new_context(self, user_agent):
+        self.new_context_calls.append({"user_agent": user_agent})
+        return self.context
 
     def close(self):
         self.closed = True
+
+
+class FakeBrowserContext:
+    def __init__(self, page):
+        self.page = page
+        self.new_page_calls = 0
+
+    def new_page(self):
+        self.new_page_calls += 1
+        return self.page
 
 
 class FakeChromium:

--- a/tests/unit/carsandbids/test_ingest.py
+++ b/tests/unit/carsandbids/test_ingest.py
@@ -6,6 +6,7 @@ import pytest
 from psycopg.types.json import Jsonb
 
 from app.sources.carsandbids import ingest
+from app.sources.carsandbids.browser import CARSANDBIDS_CHROME_USER_AGENT
 from app.sources.carsandbids.ingest import (
     build_listing_url,
     evaluate_listing_eligibility,
@@ -170,6 +171,10 @@ def test_fetch_listing_json_captures_matching_response(mocker, caplog):
         ("https://carsandbids.com/auctions/test-auction", "domcontentloaded", 60000)
     ]
     assert playwright.chromium.launch_calls == [{"headless": True}]
+    assert playwright.chromium.browser.new_context_calls == [
+        {"user_agent": CARSANDBIDS_CHROME_USER_AGENT}
+    ]
+    assert playwright.chromium.browser.context.new_page_calls == 1
     assert (
         "Fetching Cars and Bids listing JSON for listing_id=test-auction"
         in caplog.text
@@ -360,13 +365,26 @@ class FakePage:
 class FakeBrowser:
     def __init__(self, page):
         self.page = page
+        self.context = FakeBrowserContext(page)
+        self.new_context_calls = []
         self.closed = False
 
-    def new_page(self):
-        return self.page
+    def new_context(self, user_agent):
+        self.new_context_calls.append({"user_agent": user_agent})
+        return self.context
 
     def close(self):
         self.closed = True
+
+
+class FakeBrowserContext:
+    def __init__(self, page):
+        self.page = page
+        self.new_page_calls = 0
+
+    def new_page(self):
+        self.new_page_calls += 1
+        return self.page
 
 
 class FakeChromium:


### PR DESCRIPTION
## Summary

- Add a Cars and Bids Playwright browser helper with one shared normal Chrome user agent constant.
- Create discovery and ingest pages from a helper-created browser context instead of the default browser page.
- Update Cars and Bids discovery and ingest unit fakes/assertions for context creation.

## Validation

- `.venv\Scripts\python.exe -m pytest -q tests\unit\carsandbids\test_discovery.py` — 34 passed
- `.venv\Scripts\python.exe -m pytest -q tests\unit\carsandbids\test_ingest.py` — 29 passed
- `.venv\Scripts\python.exe -m pytest -q tests\unit\carsandbids\test_pipeline.py` — 13 passed
- Live headless discovery smoke captured 50 auctions with a signed response.
- Live headless ingest smoke fetched listing `3pnjnnx6` with status `sold`.

Closes #114