### PR TITLE
[codex] Reuse Cars and Bids batch context

### DIFF
--- a/app/pipeline/carsandbids.py
+++ b/app/pipeline/carsandbids.py
@@ -1,6 +1,9 @@
 import logging
 from dataclasses import dataclass
 
+from playwright.sync_api import sync_playwright
+
+from app.sources.carsandbids.browser import launch_carsandbids_browser_context
 from app.sources.carsandbids.discovery import (
     discover_completed_auctions,
     load_pending_discovered_listings,
@@ -9,6 +12,7 @@ from app.sources.carsandbids.discovery import (
 from app.sources.carsandbids.ingest import (
     evaluate_listing_eligibility,
     fetch_listing_json,
+    fetch_listing_json_with_context,
     save_listing_json,
 )
 from app.sources.carsandbids.load import load_listing
@@ -72,37 +76,46 @@ def ingest_discovered_listings(batch_size=None):
     summary = BatchIngestSummary()
     pending_rows = load_pending_discovered_listings(limit=batch_size)
 
-    for row in pending_rows:
-        summary.selected += 1
-        listing_id = row["source_listing_id"]
+    if not pending_rows:
+        return summary
 
-        summary.scrape_attempted += 1
+    with sync_playwright() as playwright:
+        browser, context = launch_carsandbids_browser_context(playwright, headless=True)
         try:
-            payload = fetch_listing_json(listing_id)
-        except Exception as exc:
-            summary.scrape_failed += 1
-            logger.error(
-                "carsandbids ingest-discovered scrape failed for listing_id=%s error=%s",
-                listing_id,
-                exc,
-            )
-            continue
+            for row in pending_rows:
+                summary.selected += 1
+                listing_id = row["source_listing_id"]
 
-        eligible, reason = evaluate_listing_eligibility(payload)
-        mark_discovered_listing_handled(listing_id, eligible, reason)
-        if not eligible:
-            logger.info(
-                "carsandbids ingest-discovered listing rejected for listing_id=%s "
-                "reason=%s",
-                listing_id,
-                reason,
-            )
-            summary.rejected += 1
-            continue
+                summary.scrape_attempted += 1
+                try:
+                    payload = fetch_listing_json_with_context(listing_id, context)
+                except Exception as exc:
+                    summary.scrape_failed += 1
+                    logger.error(
+                        "carsandbids ingest-discovered scrape failed "
+                        "for listing_id=%s error=%s",
+                        listing_id,
+                        exc,
+                    )
+                    continue
 
-        save_listing_json(listing_id, payload, url=row["url"])
-        summary.raw_json_stored += 1
-        summary.accepted += 1
+                eligible, reason = evaluate_listing_eligibility(payload)
+                mark_discovered_listing_handled(listing_id, eligible, reason)
+                if not eligible:
+                    logger.info(
+                        "carsandbids ingest-discovered listing rejected "
+                        "for listing_id=%s reason=%s",
+                        listing_id,
+                        reason,
+                    )
+                    summary.rejected += 1
+                    continue
+
+                save_listing_json(listing_id, payload, url=row["url"])
+                summary.raw_json_stored += 1
+                summary.accepted += 1
+        finally:
+            browser.close()
 
     return summary
 

--- a/app/sources/carsandbids/ingest.py
+++ b/app/sources/carsandbids/ingest.py
@@ -50,7 +50,7 @@ def build_listing_url(listing_id):
     return f"{LISTING_URL_BASE}/{listing_id}"
 
 
-def fetch_listing_json(listing_id):
+def _fetch_listing_json_with_page(listing_id, page):
     listing_url = build_listing_url(listing_id)
     api_url_prefix = f"{API_AUCTION_URL_BASE}/{listing_id}"
     matched_response = None
@@ -63,50 +63,61 @@ def fetch_listing_json(listing_id):
         if matched_response is None and is_matching_response(response):
             matched_response = response
 
-    logger.info("Fetching Cars and Bids listing JSON for listing_id=%s", listing_id)
-    with sync_playwright() as playwright:
-        browser, context = launch_carsandbids_browser_context(playwright, headless=True)
+    page.on("response", capture_matching_response)
+    page.goto(
+        listing_url,
+        wait_until="domcontentloaded",
+        timeout=PAGE_LOAD_TIMEOUT_MS,
+    )
+    if matched_response is None:
         try:
-            page = context.new_page()
-            page.on("response", capture_matching_response)
-            page.goto(
-                listing_url,
-                wait_until="domcontentloaded",
-                timeout=PAGE_LOAD_TIMEOUT_MS,
+            matched_response = page.wait_for_event(
+                "response",
+                predicate=is_matching_response,
+                timeout=API_RESPONSE_TIMEOUT_MS,
             )
-            if matched_response is None:
-                try:
-                    matched_response = page.wait_for_event(
-                        "response",
-                        predicate=is_matching_response,
-                        timeout=API_RESPONSE_TIMEOUT_MS,
-                    )
-                except Exception as exc:
-                    raise RuntimeError(
-                        "Cars and Bids API response not found "
-                        f"for listing_id={listing_id}"
-                    ) from exc
+        except Exception as exc:
+            raise RuntimeError(
+                "Cars and Bids API response not found "
+                f"for listing_id={listing_id}"
+            ) from exc
 
-            if matched_response is None:
-                raise RuntimeError(
-                    f"Cars and Bids API response not found for listing_id={listing_id}"
-                )
-            if not matched_response.ok:
-                raise RuntimeError(
-                    "Cars and Bids API response failed "
-                    f"for listing_id={listing_id} status={matched_response.status}"
-                )
-            try:
-                payload = matched_response.json()
-            except Exception as exc:
-                raise RuntimeError(
-                    f"Invalid Cars and Bids API JSON for listing_id={listing_id}"
-                ) from exc
-        finally:
-            browser.close()
+    if matched_response is None:
+        raise RuntimeError(
+            f"Cars and Bids API response not found for listing_id={listing_id}"
+        )
+    if not matched_response.ok:
+        raise RuntimeError(
+            "Cars and Bids API response failed "
+            f"for listing_id={listing_id} status={matched_response.status}"
+        )
+    try:
+        payload = matched_response.json()
+    except Exception as exc:
+        raise RuntimeError(
+            f"Invalid Cars and Bids API JSON for listing_id={listing_id}"
+        ) from exc
 
     logger.info("Fetched Cars and Bids listing JSON for listing_id=%s", listing_id)
     return payload
+
+
+def fetch_listing_json_with_context(listing_id, context):
+    logger.info("Fetching Cars and Bids listing JSON for listing_id=%s", listing_id)
+    page = context.new_page()
+    try:
+        return _fetch_listing_json_with_page(listing_id, page)
+    finally:
+        page.close()
+
+
+def fetch_listing_json(listing_id):
+    with sync_playwright() as playwright:
+        browser, context = launch_carsandbids_browser_context(playwright, headless=True)
+        try:
+            return fetch_listing_json_with_context(listing_id, context)
+        finally:
+            browser.close()
 
 
 def evaluate_listing_eligibility(payload):

--- a/tests/unit/carsandbids/test_ingest.py
+++ b/tests/unit/carsandbids/test_ingest.py
@@ -11,6 +11,7 @@ from app.sources.carsandbids.ingest import (
     build_listing_url,
     evaluate_listing_eligibility,
     fetch_listing_json,
+    fetch_listing_json_with_context,
     save_listing_json,
 )
 
@@ -175,12 +176,32 @@ def test_fetch_listing_json_captures_matching_response(mocker, caplog):
         {"user_agent": CARSANDBIDS_CHROME_USER_AGENT}
     ]
     assert playwright.chromium.browser.context.new_page_calls == 1
+    assert page.closed is True
     assert (
         "Fetching Cars and Bids listing JSON for listing_id=test-auction"
         in caplog.text
     )
     assert "Fetched Cars and Bids listing JSON for listing_id=test-auction" in caplog.text
     assert "Test Listing" not in caplog.text
+
+
+def test_fetch_listing_json_with_context_uses_existing_context_and_closes_page():
+    payload = {"id": "test-auction", "title": "Test Listing"}
+    response = FakeResponse(
+        "https://carsandbids.com/v2/autos/auctions/test-auction?include=seller",
+        payload=payload,
+    )
+    page = FakePage([response])
+    context = FakeBrowserContext(page)
+
+    result = fetch_listing_json_with_context("test-auction", context)
+
+    assert result == payload
+    assert context.new_page_calls == 1
+    assert page.goto_calls == [
+        ("https://carsandbids.com/auctions/test-auction", "domcontentloaded", 60000)
+    ]
+    assert page.closed is True
 
 
 def test_fetch_listing_json_raises_when_matching_response_is_absent(mocker):
@@ -343,6 +364,7 @@ class FakePage:
         self.responses = responses
         self.response_handler = None
         self.goto_calls = []
+        self.closed = False
 
     def on(self, event_name, handler):
         assert event_name == "response"
@@ -360,6 +382,9 @@ class FakePage:
             if predicate(response):
                 return response
         raise TimeoutError("response not found")
+
+    def close(self):
+        self.closed = True
 
 
 class FakeBrowser:

--- a/tests/unit/carsandbids/test_pipeline.py
+++ b/tests/unit/carsandbids/test_pipeline.py
@@ -4,6 +4,24 @@ from datetime import date
 from app.pipeline import carsandbids
 
 
+def _patch_batch_browser(mocker):
+    fake_playwright = object()
+    fake_browser = mocker.Mock()
+    fake_context = mocker.Mock(name="carsandbids_context")
+    playwright_manager = mocker.MagicMock()
+    playwright_manager.__enter__.return_value = fake_playwright
+    playwright_manager.__exit__.return_value = False
+    sync_playwright = mocker.patch(
+        "app.pipeline.carsandbids.sync_playwright",
+        return_value=playwright_manager,
+    )
+    launch_context = mocker.patch(
+        "app.pipeline.carsandbids.launch_carsandbids_browser_context",
+        return_value=(fake_browser, fake_context),
+    )
+    return fake_playwright, fake_browser, fake_context, sync_playwright, launch_context
+
+
 def test_ingest_listing_fetches_and_saves_listing_json(mocker):
     payload = {"listing": {"year": 2004}}
     fetch_listing_json = mocker.patch(
@@ -141,10 +159,16 @@ def test_ingest_discovered_listings_returns_zeroed_summary_for_empty_batch(mocke
         "app.pipeline.carsandbids.load_pending_discovered_listings",
         return_value=[],
     )
+    sync_playwright = mocker.patch("app.pipeline.carsandbids.sync_playwright")
+    launch_context = mocker.patch(
+        "app.pipeline.carsandbids.launch_carsandbids_browser_context"
+    )
 
     summary = carsandbids.ingest_discovered_listings()
 
     assert summary == carsandbids.BatchIngestSummary()
+    sync_playwright.assert_not_called()
+    launch_context.assert_not_called()
 
 
 def test_transform_discovered_listings_returns_zeroed_summary_for_empty_batch(mocker):
@@ -160,6 +184,9 @@ def test_transform_discovered_listings_returns_zeroed_summary_for_empty_batch(mo
 
 def test_ingest_discovered_listings_marks_reject_without_saving_json(mocker, caplog):
     payload = {"listing": {"year": 1940}}
+    fake_playwright, fake_browser, fake_context, _, launch_context = (
+        _patch_batch_browser(mocker)
+    )
     mocker.patch(
         "app.pipeline.carsandbids.load_pending_discovered_listings",
         return_value=[
@@ -170,7 +197,10 @@ def test_ingest_discovered_listings_marks_reject_without_saving_json(mocker, cap
             }
         ],
     )
-    mocker.patch("app.pipeline.carsandbids.fetch_listing_json", return_value=payload)
+    fetch_listing_json_with_context = mocker.patch(
+        "app.pipeline.carsandbids.fetch_listing_json_with_context",
+        return_value=payload,
+    )
     evaluate_listing_eligibility = mocker.patch(
         "app.pipeline.carsandbids.evaluate_listing_eligibility",
         return_value=(False, "year before 1946"),
@@ -183,6 +213,9 @@ def test_ingest_discovered_listings_marks_reject_without_saving_json(mocker, cap
     caplog.set_level(logging.INFO)
     summary = carsandbids.ingest_discovered_listings()
 
+    launch_context.assert_called_once_with(fake_playwright, headless=True)
+    fetch_listing_json_with_context.assert_called_once_with("rejected", fake_context)
+    fake_browser.close.assert_called_once_with()
     evaluate_listing_eligibility.assert_called_once_with(payload)
     mark_handled.assert_called_once_with("rejected", False, "year before 1946")
     save_listing_json.assert_not_called()
@@ -198,6 +231,7 @@ def test_ingest_discovered_listings_marks_reject_without_saving_json(mocker, cap
 
 
 def test_ingest_discovered_listings_records_scrape_failure_without_marking_row(mocker):
+    _, fake_browser, fake_context, _, _ = _patch_batch_browser(mocker)
     mocker.patch(
         "app.pipeline.carsandbids.load_pending_discovered_listings",
         return_value=[
@@ -208,8 +242,8 @@ def test_ingest_discovered_listings_records_scrape_failure_without_marking_row(m
             }
         ],
     )
-    mocker.patch(
-        "app.pipeline.carsandbids.fetch_listing_json",
+    fetch_listing_json_with_context = mocker.patch(
+        "app.pipeline.carsandbids.fetch_listing_json_with_context",
         side_effect=RuntimeError("network failed"),
     )
     mark_handled = mocker.patch(
@@ -218,6 +252,8 @@ def test_ingest_discovered_listings_records_scrape_failure_without_marking_row(m
 
     summary = carsandbids.ingest_discovered_listings()
 
+    fetch_listing_json_with_context.assert_called_once_with("scrape-fail", fake_context)
+    fake_browser.close.assert_called_once_with()
     mark_handled.assert_not_called()
     assert summary == carsandbids.BatchIngestSummary(
         selected=1,
@@ -228,6 +264,7 @@ def test_ingest_discovered_listings_records_scrape_failure_without_marking_row(m
 
 def test_ingest_discovered_listings_saves_json_and_marks_eligible_for_pass(mocker):
     payload = {"listing": {"year": 2004}}
+    _, fake_browser, fake_context, _, _ = _patch_batch_browser(mocker)
     mocker.patch(
         "app.pipeline.carsandbids.load_pending_discovered_listings",
         return_value=[
@@ -238,7 +275,10 @@ def test_ingest_discovered_listings_saves_json_and_marks_eligible_for_pass(mocke
             }
         ],
     )
-    mocker.patch("app.pipeline.carsandbids.fetch_listing_json", return_value=payload)
+    fetch_listing_json_with_context = mocker.patch(
+        "app.pipeline.carsandbids.fetch_listing_json_with_context",
+        return_value=payload,
+    )
     mocker.patch(
         "app.pipeline.carsandbids.evaluate_listing_eligibility",
         return_value=(True, None),
@@ -253,6 +293,8 @@ def test_ingest_discovered_listings_saves_json_and_marks_eligible_for_pass(mocke
 
     summary = carsandbids.ingest_discovered_listings()
 
+    fetch_listing_json_with_context.assert_called_once_with("accepted", fake_context)
+    fake_browser.close.assert_called_once_with()
     save_listing_json.assert_called_once_with(
         "accepted",
         payload,
@@ -277,6 +319,7 @@ def test_ingest_discovered_listings_saves_json_and_marks_eligible_for_pass(mocke
 
 def test_ingest_discovered_listings_handles_mixed_batch_outcomes(mocker):
     accepted_payload = {"listing": {"year": 2004}}
+    _, fake_browser, fake_context, _, launch_context = _patch_batch_browser(mocker)
     mocker.patch(
         "app.pipeline.carsandbids.load_pending_discovered_listings",
         return_value=[
@@ -302,8 +345,8 @@ def test_ingest_discovered_listings_handles_mixed_batch_outcomes(mocker):
             },
         ],
     )
-    mocker.patch(
-        "app.pipeline.carsandbids.fetch_listing_json",
+    fetch_listing_json_with_context = mocker.patch(
+        "app.pipeline.carsandbids.fetch_listing_json_with_context",
         side_effect=[
             {"listing": {"year": 1940}},
             RuntimeError("network failed"),
@@ -329,6 +372,14 @@ def test_ingest_discovered_listings_handles_mixed_batch_outcomes(mocker):
 
     summary = carsandbids.ingest_discovered_listings()
 
+    launch_context.assert_called_once()
+    assert fetch_listing_json_with_context.call_args_list == [
+        mocker.call("year-reject", fake_context),
+        mocker.call("scrape-fail", fake_context),
+        mocker.call("model-reject", fake_context),
+        mocker.call("accepted", fake_context),
+    ]
+    fake_browser.close.assert_called_once_with()
     assert summary == carsandbids.BatchIngestSummary(
         selected=4,
         scrape_attempted=4,


### PR DESCRIPTION
## Summary

- Reuses one headless Cars and Bids Playwright browser/context for each non-empty discovered batch ingest.
- Adds a context-aware listing JSON fetch path while keeping `fetch_listing_json(listing_id)` as the single-listing API.
- Preserves selected row order, per-row scrape failure handling, rejected row handling, and accepted row storage/counting.

Closes #115.

## Verification

- `.venv\Scripts\python.exe -m pytest -q tests\unit\carsandbids\test_ingest.py`
  - `30 passed in 0.24s`
- `.venv\Scripts\python.exe -m pytest -q tests\unit\carsandbids\test_pipeline.py`
  - `13 passed in 0.22s`
- `.venv\Scripts\python.exe -m pytest -q tests\unit\carsandbids`
  - `121 passed in 0.36s`

## Live Smoke

- Discovered current completed Cars and Bids listings headlessly.
- Fetched two discovered listing IDs through one reused headless Cars and Bids context.
- Result: `{'ids': ['925DvpWQ', '3qJN8EEe'], 'fetched': ['925DvpWQ', '3qJN8EEe'], 'count': 2}`

The initial sandboxed Playwright run failed with `PermissionError: [WinError 5] Access is denied`; the escalated rerun succeeded.
