### PR TITLE
Add summary output for single-listing CLI commands

### DIFF
--- a/app/pipeline/bat.py
+++ b/app/pipeline/bat.py
@@ -40,27 +40,83 @@ class BatchTransformSummary:
     load_failed: int = 0
 
 
+@dataclass
+class SingleIngestSummary:
+    listing_id: str
+    accepted: bool
+    raw_stored: bool
+    reason: str | None = None
+
+
+@dataclass
+class SingleTransformSummary:
+    listing_id: str
+    transformed: bool
+    loaded: bool
+
+
+@dataclass
+class SingleRunSummary:
+    listing_id: str
+    accepted: bool
+    raw_stored: bool
+    transformed: bool
+    loaded: bool
+    reason: str | None = None
+
+
 def ingest_listing(listing_id):
     html = fetch_listing_html(listing_id)
     soup = BeautifulSoup(html, "html.parser")
     eligible, reason = evaluate_listing_eligibility(soup, listing_id)
     mark_discovered_listing_handled(listing_id, eligible, reason)
-    
+
     if not eligible:
-        return False
-    
+        return SingleIngestSummary(
+            listing_id=listing_id,
+            accepted=False,
+            raw_stored=False,
+            reason=reason,
+        )
+
     save_listing_html(listing_id, html)
-    return True
+    return SingleIngestSummary(
+        listing_id=listing_id,
+        accepted=True,
+        raw_stored=True,
+    )
+
 
 def transform_listing(listing_id):
     transformed_listing = transform_listing_html(listing_id)
     load_listing(transformed_listing)
+    return SingleTransformSummary(
+        listing_id=listing_id,
+        transformed=True,
+        loaded=True,
+    )
 
 
 def run_listing(listing_id):
-    if not ingest_listing(listing_id):
-        return
-    transform_listing(listing_id)
+    ingest_summary = ingest_listing(listing_id)
+    if not ingest_summary.accepted:
+        return SingleRunSummary(
+            listing_id=listing_id,
+            accepted=False,
+            raw_stored=False,
+            transformed=False,
+            loaded=False,
+            reason=ingest_summary.reason,
+        )
+
+    transform_summary = transform_listing(listing_id)
+    return SingleRunSummary(
+        listing_id=listing_id,
+        accepted=True,
+        raw_stored=ingest_summary.raw_stored,
+        transformed=transform_summary.transformed,
+        loaded=transform_summary.loaded,
+    )
 
 
 def discover_listings(scrape_date, max_candidates=None):

--- a/app/pipeline/carsandbids.py
+++ b/app/pipeline/carsandbids.py
@@ -42,27 +42,82 @@ class BatchTransformSummary:
     load_failed: int = 0
 
 
+@dataclass
+class SingleIngestSummary:
+    listing_id: str
+    accepted: bool
+    raw_stored: bool
+    reason: str | None = None
+
+
+@dataclass
+class SingleTransformSummary:
+    listing_id: str
+    transformed: bool
+    loaded: bool
+
+
+@dataclass
+class SingleRunSummary:
+    listing_id: str
+    accepted: bool
+    raw_stored: bool
+    transformed: bool
+    loaded: bool
+    reason: str | None = None
+
+
 def ingest_listing(listing_id):
     payload = fetch_listing_json(listing_id)
     eligible, reason = evaluate_listing_eligibility(payload)
     mark_discovered_listing_handled(listing_id, eligible, reason)
 
     if not eligible:
-        return False
+        return SingleIngestSummary(
+            listing_id=listing_id,
+            accepted=False,
+            raw_stored=False,
+            reason=reason,
+        )
 
     save_listing_json(listing_id, payload)
-    return True
+    return SingleIngestSummary(
+        listing_id=listing_id,
+        accepted=True,
+        raw_stored=True,
+    )
 
 
 def transform_listing(listing_id):
     transformed_listing = transform_listing_json(listing_id)
     load_listing(transformed_listing)
+    return SingleTransformSummary(
+        listing_id=listing_id,
+        transformed=True,
+        loaded=True,
+    )
 
 
 def run_listing(listing_id):
-    if not ingest_listing(listing_id):
-        return
-    transform_listing(listing_id)
+    ingest_summary = ingest_listing(listing_id)
+    if not ingest_summary.accepted:
+        return SingleRunSummary(
+            listing_id=listing_id,
+            accepted=False,
+            raw_stored=False,
+            transformed=False,
+            loaded=False,
+            reason=ingest_summary.reason,
+        )
+
+    transform_summary = transform_listing(listing_id)
+    return SingleRunSummary(
+        listing_id=listing_id,
+        accepted=True,
+        raw_stored=ingest_summary.raw_stored,
+        transformed=transform_summary.transformed,
+        loaded=transform_summary.loaded,
+    )
 
 
 def discover_listings(scrape_date, max_candidates=None):

--- a/app/sources/bat/cli.py
+++ b/app/sources/bat/cli.py
@@ -43,6 +43,39 @@ def configure_logging():
     )
 
 
+def _format_bool(value):
+    return str(value).lower()
+
+
+def _print_ingest_summary(summary):
+    print(
+        "Ingest summary: "
+        f"listing_id={summary.listing_id} "
+        f"accepted={_format_bool(summary.accepted)} "
+        f"raw_stored={_format_bool(summary.raw_stored)}"
+    )
+
+
+def _print_transform_summary(summary):
+    print(
+        "Transform summary: "
+        f"listing_id={summary.listing_id} "
+        f"transformed={_format_bool(summary.transformed)} "
+        f"loaded={_format_bool(summary.loaded)}"
+    )
+
+
+def _print_run_summary(summary):
+    print(
+        "Run summary: "
+        f"listing_id={summary.listing_id} "
+        f"accepted={_format_bool(summary.accepted)} "
+        f"raw_stored={_format_bool(summary.raw_stored)} "
+        f"transformed={_format_bool(summary.transformed)} "
+        f"loaded={_format_bool(summary.loaded)}"
+    )
+
+
 def main(argv=None):
     configure_logging()
     args = build_parser().parse_args(argv)
@@ -131,11 +164,14 @@ def main(argv=None):
 
         logger.info("BAT %s command started for listing_id=%s", args.command, args.listing_id)
         if args.command == "ingest":
-            bat_pipeline.ingest_listing(args.listing_id)
+            summary = bat_pipeline.ingest_listing(args.listing_id)
+            _print_ingest_summary(summary)
         elif args.command == "transform":
-            bat_pipeline.transform_listing(args.listing_id)
+            summary = bat_pipeline.transform_listing(args.listing_id)
+            _print_transform_summary(summary)
         elif args.command == "run":
-            bat_pipeline.run_listing(args.listing_id)
+            summary = bat_pipeline.run_listing(args.listing_id)
+            _print_run_summary(summary)
     except Exception:
         if args.command == "discover":
             logger.error(

--- a/app/sources/carsandbids/cli.py
+++ b/app/sources/carsandbids/cli.py
@@ -43,6 +43,39 @@ def configure_logging():
     )
 
 
+def _format_bool(value):
+    return str(value).lower()
+
+
+def _print_ingest_summary(summary):
+    print(
+        "Ingest summary: "
+        f"listing_id={summary.listing_id} "
+        f"accepted={_format_bool(summary.accepted)} "
+        f"raw_stored={_format_bool(summary.raw_stored)}"
+    )
+
+
+def _print_transform_summary(summary):
+    print(
+        "Transform summary: "
+        f"listing_id={summary.listing_id} "
+        f"transformed={_format_bool(summary.transformed)} "
+        f"loaded={_format_bool(summary.loaded)}"
+    )
+
+
+def _print_run_summary(summary):
+    print(
+        "Run summary: "
+        f"listing_id={summary.listing_id} "
+        f"accepted={_format_bool(summary.accepted)} "
+        f"raw_stored={_format_bool(summary.raw_stored)} "
+        f"transformed={_format_bool(summary.transformed)} "
+        f"loaded={_format_bool(summary.loaded)}"
+    )
+
+
 def main(argv=None):
     configure_logging()
     args = build_parser().parse_args(argv)
@@ -142,11 +175,14 @@ def main(argv=None):
             args.listing_id,
         )
         if args.command == "ingest":
-            carsandbids_pipeline.ingest_listing(args.listing_id)
+            summary = carsandbids_pipeline.ingest_listing(args.listing_id)
+            _print_ingest_summary(summary)
         elif args.command == "transform":
-            carsandbids_pipeline.transform_listing(args.listing_id)
+            summary = carsandbids_pipeline.transform_listing(args.listing_id)
+            _print_transform_summary(summary)
         elif args.command == "run":
-            carsandbids_pipeline.run_listing(args.listing_id)
+            summary = carsandbids_pipeline.run_listing(args.listing_id)
+            _print_run_summary(summary)
     except Exception:
         if args.command == "discover":
             logger.error(

--- a/tests/unit/bat/test_cli.py
+++ b/tests/unit/bat/test_cli.py
@@ -7,8 +7,15 @@ from app.pipeline import bat
 from app.sources.bat import cli
 
 
-def test_ingest_command_fetches_and_saves_listing_html(mocker, caplog):
-    ingest_listing = mocker.patch("app.sources.bat.cli.bat_pipeline.ingest_listing")
+def test_ingest_command_fetches_and_saves_listing_html(mocker, caplog, capsys):
+    ingest_listing = mocker.patch(
+        "app.sources.bat.cli.bat_pipeline.ingest_listing",
+        return_value=bat.SingleIngestSummary(
+            listing_id="test-id",
+            accepted=True,
+            raw_stored=True,
+        ),
+    )
 
     caplog.set_level(logging.INFO)
     cli.main(["ingest", "--listing-id", "test-id"])
@@ -16,9 +23,53 @@ def test_ingest_command_fetches_and_saves_listing_html(mocker, caplog):
     ingest_listing.assert_called_once_with("test-id")
     assert "BAT ingest command started for listing_id=test-id" in caplog.text
     assert "BAT ingest command completed for listing_id=test-id" in caplog.text
+    assert (
+        "Ingest summary: listing_id=test-id accepted=true raw_stored=true\n"
+        == capsys.readouterr().out
+    )
 
 
-def test_transform_command_logs_failure_context_without_traceback_and_reraises(mocker, caplog):
+def test_ingest_command_prints_rejected_summary_without_reason(mocker, capsys):
+    mocker.patch(
+        "app.sources.bat.cli.bat_pipeline.ingest_listing",
+        return_value=bat.SingleIngestSummary(
+            listing_id="test-id",
+            accepted=False,
+            raw_stored=False,
+            reason="year before 1946",
+        ),
+    )
+
+    cli.main(["ingest", "--listing-id", "test-id"])
+
+    out = capsys.readouterr().out
+    assert out == "Ingest summary: listing_id=test-id accepted=false raw_stored=false\n"
+    assert "reason" not in out
+    assert "source" not in out
+
+
+def test_transform_command_prints_summary(mocker, capsys):
+    transform_listing = mocker.patch(
+        "app.sources.bat.cli.bat_pipeline.transform_listing",
+        return_value=bat.SingleTransformSummary(
+            listing_id="test-id",
+            transformed=True,
+            loaded=True,
+        ),
+    )
+
+    cli.main(["transform", "--listing-id", "test-id"])
+
+    transform_listing.assert_called_once_with("test-id")
+    assert (
+        "Transform summary: listing_id=test-id transformed=true loaded=true\n"
+        == capsys.readouterr().out
+    )
+
+
+def test_transform_command_logs_failure_context_without_traceback_and_reraises(
+    mocker, caplog, capsys
+):
     error = RuntimeError("transform failed")
     mocker.patch(
         "app.sources.bat.cli.bat_pipeline.transform_listing",
@@ -34,14 +85,52 @@ def test_transform_command_logs_failure_context_without_traceback_and_reraises(m
     assert "BAT transform command failed for listing_id=test-id" in caplog.text
     assert "Traceback" not in caplog.text
     assert "RuntimeError: transform failed" not in caplog.text
+    assert "Transform summary:" not in capsys.readouterr().out
 
 
-def test_run_command_executes_ingest_transform_load_in_order(mocker):
-    run_listing = mocker.patch("app.sources.bat.cli.bat_pipeline.run_listing")
+def test_run_command_executes_ingest_transform_load_in_order(mocker, capsys):
+    run_listing = mocker.patch(
+        "app.sources.bat.cli.bat_pipeline.run_listing",
+        return_value=bat.SingleRunSummary(
+            listing_id="test-id",
+            accepted=True,
+            raw_stored=True,
+            transformed=True,
+            loaded=True,
+        ),
+    )
 
     cli.main(["run", "--listing-id", "test-id"])
 
     run_listing.assert_called_once_with("test-id")
+    assert (
+        "Run summary: listing_id=test-id accepted=true raw_stored=true "
+        "transformed=true loaded=true\n"
+    ) == capsys.readouterr().out
+
+
+def test_run_command_prints_rejected_summary_without_reason(mocker, capsys):
+    mocker.patch(
+        "app.sources.bat.cli.bat_pipeline.run_listing",
+        return_value=bat.SingleRunSummary(
+            listing_id="test-id",
+            accepted=False,
+            raw_stored=False,
+            transformed=False,
+            loaded=False,
+            reason="year before 1946",
+        ),
+    )
+
+    cli.main(["run", "--listing-id", "test-id"])
+
+    out = capsys.readouterr().out
+    assert (
+        "Run summary: listing_id=test-id accepted=false raw_stored=false "
+        "transformed=false loaded=false\n"
+    ) == out
+    assert "reason" not in out
+    assert "source" not in out
 
 
 def test_discover_command_parses_without_listing_id():

--- a/tests/unit/bat/test_pipeline.py
+++ b/tests/unit/bat/test_pipeline.py
@@ -18,7 +18,7 @@ def test_ingest_listing_fetches_and_saves_listing_html(mocker):
         "app.pipeline.bat.mark_discovered_listing_handled"
     )
 
-    bat.ingest_listing("test-id")
+    summary = bat.ingest_listing("test-id")
 
     fetch_listing_html.assert_called_once_with("test-id")
     evaluate_listing_eligibility.assert_called_once()
@@ -27,6 +27,41 @@ def test_ingest_listing_fetches_and_saves_listing_html(mocker):
     assert listing_id == "test-id"
     mark_discovered_listing_handled.assert_called_once_with("test-id", True, None)
     save_listing_html.assert_called_once_with("test-id", "<html>Test</html>")
+    assert summary == bat.SingleIngestSummary(
+        listing_id="test-id",
+        accepted=True,
+        raw_stored=True,
+    )
+
+
+def test_ingest_listing_marks_rejected_listing_without_saving_html(mocker):
+    mocker.patch(
+        "app.pipeline.bat.fetch_listing_html",
+        return_value="<html>Test</html>",
+    )
+    mocker.patch(
+        "app.pipeline.bat.evaluate_listing_eligibility",
+        return_value=(False, "year before 1946"),
+    )
+    mark_discovered_listing_handled = mocker.patch(
+        "app.pipeline.bat.mark_discovered_listing_handled"
+    )
+    save_listing_html = mocker.patch("app.pipeline.bat.save_listing_html")
+
+    summary = bat.ingest_listing("test-id")
+
+    mark_discovered_listing_handled.assert_called_once_with(
+        "test-id",
+        False,
+        "year before 1946",
+    )
+    save_listing_html.assert_not_called()
+    assert summary == bat.SingleIngestSummary(
+        listing_id="test-id",
+        accepted=False,
+        raw_stored=False,
+        reason="year before 1946",
+    )
 
 
 def test_transform_listing_transforms_and_loads_listing(mocker):
@@ -37,10 +72,15 @@ def test_transform_listing_transforms_and_loads_listing(mocker):
     )
     load_listing = mocker.patch("app.pipeline.bat.load_listing")
 
-    bat.transform_listing("test-id")
+    summary = bat.transform_listing("test-id")
 
     transform_listing_html.assert_called_once_with("test-id")
     load_listing.assert_called_once_with(transformed_listing)
+    assert summary == bat.SingleTransformSummary(
+        listing_id="test-id",
+        transformed=True,
+        loaded=True,
+    )
 
 
 def test_run_listing_executes_ingest_transform_load_in_order(mocker):
@@ -75,7 +115,7 @@ def test_run_listing_executes_ingest_transform_load_in_order(mocker):
         side_effect=lambda listing: calls.append(("load", listing)),
     )
 
-    bat.run_listing("test-id")
+    summary = bat.run_listing("test-id")
 
     assert calls == [
         ("fetch", "test-id"),
@@ -85,6 +125,38 @@ def test_run_listing_executes_ingest_transform_load_in_order(mocker):
         ("transform", "test-id"),
         ("load", transformed_listing),
     ]
+    assert summary == bat.SingleRunSummary(
+        listing_id="test-id",
+        accepted=True,
+        raw_stored=True,
+        transformed=True,
+        loaded=True,
+    )
+
+
+def test_run_listing_skips_transform_when_ingest_rejects_listing(mocker):
+    mocker.patch(
+        "app.pipeline.bat.ingest_listing",
+        return_value=bat.SingleIngestSummary(
+            listing_id="test-id",
+            accepted=False,
+            raw_stored=False,
+            reason="year before 1946",
+        ),
+    )
+    transform_listing = mocker.patch("app.pipeline.bat.transform_listing")
+
+    summary = bat.run_listing("test-id")
+
+    transform_listing.assert_not_called()
+    assert summary == bat.SingleRunSummary(
+        listing_id="test-id",
+        accepted=False,
+        raw_stored=False,
+        transformed=False,
+        loaded=False,
+        reason="year before 1946",
+    )
 
 
 def test_discover_listings_delegates_to_discovery(mocker):

--- a/tests/unit/carsandbids/test_cli.py
+++ b/tests/unit/carsandbids/test_cli.py
@@ -7,9 +7,14 @@ from app.pipeline import carsandbids
 from app.sources.carsandbids import cli
 
 
-def test_ingest_command_fetches_and_saves_listing_json(mocker, caplog):
+def test_ingest_command_fetches_and_saves_listing_json(mocker, caplog, capsys):
     ingest_listing = mocker.patch(
-        "app.sources.carsandbids.cli.carsandbids_pipeline.ingest_listing"
+        "app.sources.carsandbids.cli.carsandbids_pipeline.ingest_listing",
+        return_value=carsandbids.SingleIngestSummary(
+            listing_id="test-id",
+            accepted=True,
+            raw_stored=True,
+        ),
     )
 
     caplog.set_level(logging.INFO)
@@ -18,10 +23,52 @@ def test_ingest_command_fetches_and_saves_listing_json(mocker, caplog):
     ingest_listing.assert_called_once_with("test-id")
     assert "carsandbids ingest command started for listing_id=test-id" in caplog.text
     assert "carsandbids ingest command completed for listing_id=test-id" in caplog.text
+    assert (
+        "Ingest summary: listing_id=test-id accepted=true raw_stored=true\n"
+        == capsys.readouterr().out
+    )
+
+
+def test_ingest_command_prints_rejected_summary_without_reason(mocker, capsys):
+    mocker.patch(
+        "app.sources.carsandbids.cli.carsandbids_pipeline.ingest_listing",
+        return_value=carsandbids.SingleIngestSummary(
+            listing_id="test-id",
+            accepted=False,
+            raw_stored=False,
+            reason="year before 1946",
+        ),
+    )
+
+    cli.main(["ingest", "--listing-id", "test-id"])
+
+    out = capsys.readouterr().out
+    assert out == "Ingest summary: listing_id=test-id accepted=false raw_stored=false\n"
+    assert "reason" not in out
+    assert "source" not in out
+
+
+def test_transform_command_prints_summary(mocker, capsys):
+    transform_listing = mocker.patch(
+        "app.sources.carsandbids.cli.carsandbids_pipeline.transform_listing",
+        return_value=carsandbids.SingleTransformSummary(
+            listing_id="test-id",
+            transformed=True,
+            loaded=True,
+        ),
+    )
+
+    cli.main(["transform", "--listing-id", "test-id"])
+
+    transform_listing.assert_called_once_with("test-id")
+    assert (
+        "Transform summary: listing_id=test-id transformed=true loaded=true\n"
+        == capsys.readouterr().out
+    )
 
 
 def test_transform_command_logs_failure_context_without_traceback_and_reraises(
-    mocker, caplog
+    mocker, caplog, capsys
 ):
     error = RuntimeError("transform failed")
     mocker.patch(
@@ -38,16 +85,52 @@ def test_transform_command_logs_failure_context_without_traceback_and_reraises(
     assert "carsandbids transform command failed for listing_id=test-id" in caplog.text
     assert "Traceback" not in caplog.text
     assert "RuntimeError: transform failed" not in caplog.text
+    assert "Transform summary:" not in capsys.readouterr().out
 
 
-def test_run_command_executes_ingest_transform_load_in_order(mocker):
+def test_run_command_executes_ingest_transform_load_in_order(mocker, capsys):
     run_listing = mocker.patch(
-        "app.sources.carsandbids.cli.carsandbids_pipeline.run_listing"
+        "app.sources.carsandbids.cli.carsandbids_pipeline.run_listing",
+        return_value=carsandbids.SingleRunSummary(
+            listing_id="test-id",
+            accepted=True,
+            raw_stored=True,
+            transformed=True,
+            loaded=True,
+        ),
     )
 
     cli.main(["run", "--listing-id", "test-id"])
 
     run_listing.assert_called_once_with("test-id")
+    assert (
+        "Run summary: listing_id=test-id accepted=true raw_stored=true "
+        "transformed=true loaded=true\n"
+    ) == capsys.readouterr().out
+
+
+def test_run_command_prints_rejected_summary_without_reason(mocker, capsys):
+    mocker.patch(
+        "app.sources.carsandbids.cli.carsandbids_pipeline.run_listing",
+        return_value=carsandbids.SingleRunSummary(
+            listing_id="test-id",
+            accepted=False,
+            raw_stored=False,
+            transformed=False,
+            loaded=False,
+            reason="year before 1946",
+        ),
+    )
+
+    cli.main(["run", "--listing-id", "test-id"])
+
+    out = capsys.readouterr().out
+    assert (
+        "Run summary: listing_id=test-id accepted=false raw_stored=false "
+        "transformed=false loaded=false\n"
+    ) == out
+    assert "reason" not in out
+    assert "source" not in out
 
 
 def test_discover_command_parses_without_listing_id():

--- a/tests/unit/carsandbids/test_pipeline.py
+++ b/tests/unit/carsandbids/test_pipeline.py
@@ -37,12 +37,17 @@ def test_ingest_listing_fetches_and_saves_listing_json(mocker):
         "app.pipeline.carsandbids.mark_discovered_listing_handled"
     )
 
-    assert carsandbids.ingest_listing("test-id") is True
+    summary = carsandbids.ingest_listing("test-id")
 
     fetch_listing_json.assert_called_once_with("test-id")
     evaluate_listing_eligibility.assert_called_once_with(payload)
     mark_discovered_listing_handled.assert_called_once_with("test-id", True, None)
     save_listing_json.assert_called_once_with("test-id", payload)
+    assert summary == carsandbids.SingleIngestSummary(
+        listing_id="test-id",
+        accepted=True,
+        raw_stored=True,
+    )
 
 
 def test_ingest_listing_marks_rejected_listing_without_saving_json(mocker):
@@ -60,7 +65,7 @@ def test_ingest_listing_marks_rejected_listing_without_saving_json(mocker):
     )
     save_listing_json = mocker.patch("app.pipeline.carsandbids.save_listing_json")
 
-    assert carsandbids.ingest_listing("test-id") is False
+    summary = carsandbids.ingest_listing("test-id")
 
     mark_discovered_listing_handled.assert_called_once_with(
         "test-id",
@@ -68,6 +73,12 @@ def test_ingest_listing_marks_rejected_listing_without_saving_json(mocker):
         "year before 1946",
     )
     save_listing_json.assert_not_called()
+    assert summary == carsandbids.SingleIngestSummary(
+        listing_id="test-id",
+        accepted=False,
+        raw_stored=False,
+        reason="year before 1946",
+    )
 
 
 def test_transform_listing_transforms_and_loads_listing(mocker):
@@ -78,10 +89,15 @@ def test_transform_listing_transforms_and_loads_listing(mocker):
     )
     load_listing = mocker.patch("app.pipeline.carsandbids.load_listing")
 
-    carsandbids.transform_listing("test-id")
+    summary = carsandbids.transform_listing("test-id")
 
     transform_listing_json.assert_called_once_with("test-id")
     load_listing.assert_called_once_with(transformed_listing)
+    assert summary == carsandbids.SingleTransformSummary(
+        listing_id="test-id",
+        transformed=True,
+        loaded=True,
+    )
 
 
 def test_run_listing_executes_ingest_transform_load_in_order(mocker):
@@ -120,7 +136,7 @@ def test_run_listing_executes_ingest_transform_load_in_order(mocker):
         side_effect=lambda listing: calls.append(("load", listing)),
     )
 
-    carsandbids.run_listing("test-id")
+    summary = carsandbids.run_listing("test-id")
 
     assert calls == [
         ("fetch", "test-id"),
@@ -130,15 +146,38 @@ def test_run_listing_executes_ingest_transform_load_in_order(mocker):
         ("transform", "test-id"),
         ("load", transformed_listing),
     ]
+    assert summary == carsandbids.SingleRunSummary(
+        listing_id="test-id",
+        accepted=True,
+        raw_stored=True,
+        transformed=True,
+        loaded=True,
+    )
 
 
 def test_run_listing_skips_transform_when_ingest_rejects_listing(mocker):
-    mocker.patch("app.pipeline.carsandbids.ingest_listing", return_value=False)
+    mocker.patch(
+        "app.pipeline.carsandbids.ingest_listing",
+        return_value=carsandbids.SingleIngestSummary(
+            listing_id="test-id",
+            accepted=False,
+            raw_stored=False,
+            reason="year before 1946",
+        ),
+    )
     transform_listing = mocker.patch("app.pipeline.carsandbids.transform_listing")
 
-    carsandbids.run_listing("test-id")
+    summary = carsandbids.run_listing("test-id")
 
     transform_listing.assert_not_called()
+    assert summary == carsandbids.SingleRunSummary(
+        listing_id="test-id",
+        accepted=False,
+        raw_stored=False,
+        transformed=False,
+        loaded=False,
+        reason="year before 1946",
+    )
 
 
 def test_discover_listings_delegates_to_discovery(mocker):


### PR DESCRIPTION
## Summary

- add single-listing summary dataclasses for BAT and Cars and Bids pipeline commands
- print source-neutral stdout summaries for single-listing ingest, transform, and run commands
- cover accepted and rejected summary behavior in focused unit tests

Closes #124

## Verification

```text
.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_pipeline.py tests\unit\bat\test_cli.py tests\unit\carsandbids\test_pipeline.py tests\unit\carsandbids\test_cli.py tests\unit\test_cli.py
79 passed in 0.63s
```

```text
git diff --check
```

No whitespace errors; Git reported LF-to-CRLF working-copy warnings for touched files.