### PR TITLE
[codex] Add installable auction-etl entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .venv/
 __pycache__/
 *.pyc
+*.egg-info/
 data/
 transform_backup.py
 .env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "car-auction-etl"
+version = "0.1.0"
+description = "ETL tools for completed vehicle auction listings."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "beautifulsoup4==4.13.4",
+    "certifi==2026.2.25",
+    "charset-normalizer==3.4.6",
+    "colorama==0.4.6",
+    "idna==3.11",
+    "iniconfig==2.3.0",
+    "packaging==26.0",
+    "playwright==1.58.0",
+    "pluggy==1.6.0",
+    "psycopg[binary]==3.2.13",
+    "Pygments==2.20.0",
+    "python-dotenv==1.2.1",
+    "requests==2.33.1",
+    "soupsieve==2.8.3",
+    "typing_extensions==4.15.0",
+    "urllib3==2.6.3",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest==9.0.2",
+    "pytest-mock==3.15.1",
+]
+
+[project.scripts]
+auction-etl = "app.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["app*"]
+namespaces = true
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,2 @@
-beautifulsoup4==4.13.4
-certifi==2026.2.25
-charset-normalizer==3.4.6
-colorama==0.4.6
-idna==3.11
-iniconfig==2.3.0
-packaging==26.0
-playwright==1.58.0
-pluggy==1.6.0
-psycopg[binary]==3.2.13
-Pygments==2.20.0
-pytest==9.0.2
-pytest-mock==3.15.1
-python-dotenv==1.2.1
-requests==2.33.1
-soupsieve==2.8.3
-typing_extensions==4.15.0
-urllib3==2.6.3
+# Compatibility install file. Project dependencies live in pyproject.toml.
+-e .[test]

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -1,0 +1,66 @@
+import importlib
+import tomllib
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = PROJECT_ROOT / "pyproject.toml"
+
+MOVED_REQUIREMENTS = {
+    "beautifulsoup4==4.13.4",
+    "certifi==2026.2.25",
+    "charset-normalizer==3.4.6",
+    "colorama==0.4.6",
+    "idna==3.11",
+    "iniconfig==2.3.0",
+    "packaging==26.0",
+    "playwright==1.58.0",
+    "pluggy==1.6.0",
+    "psycopg[binary]==3.2.13",
+    "Pygments==2.20.0",
+    "pytest==9.0.2",
+    "pytest-mock==3.15.1",
+    "python-dotenv==1.2.1",
+    "requests==2.33.1",
+    "soupsieve==2.8.3",
+    "typing_extensions==4.15.0",
+    "urllib3==2.6.3",
+}
+
+
+def load_pyproject():
+    return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+
+
+def test_project_metadata_defines_console_script_entrypoint():
+    project = load_pyproject()["project"]
+
+    assert project["name"] == "car-auction-etl"
+    assert project["scripts"]["auction-etl"] == "app.cli:main"
+
+
+def test_console_script_entrypoint_resolves_to_top_level_cli_main():
+    script_target = load_pyproject()["project"]["scripts"]["auction-etl"]
+    module_name, function_name = script_target.split(":", maxsplit=1)
+
+    resolved = getattr(importlib.import_module(module_name), function_name)
+
+    from app import cli
+
+    assert resolved is cli.main
+
+
+def test_moved_requirements_are_represented_in_pyproject_dependencies():
+    project = load_pyproject()["project"]
+    dependencies = set(project["dependencies"])
+    for optional_dependencies in project.get("optional-dependencies", {}).values():
+        dependencies.update(optional_dependencies)
+
+    assert MOVED_REQUIREMENTS <= dependencies
+
+
+def test_requirements_txt_points_to_editable_install():
+    requirements = (PROJECT_ROOT / "requirements.txt").read_text(encoding="utf-8")
+
+    assert "-e .[test]" in requirements
+    assert "beautifulsoup4==" not in requirements


### PR DESCRIPTION
## Summary

Adds modern Python packaging metadata so the existing top-level CLI can be installed as a console command named `auction-etl`.

## Changes

- Added `pyproject.toml` with project metadata, dependency metadata, setuptools package discovery, and `auction-etl = "app.cli:main"`.
- Moved the previous `requirements.txt` dependency list into `pyproject.toml`, with test-only packages under the `test` optional dependency group.
- Replaced `requirements.txt` with a compatibility editable install pointer to `-e .[test]`.
- Added focused packaging tests for metadata, dependency representation, and entrypoint resolution.
- Ignored generated `*.egg-info/` directories from editable installs.

## Validation

- `.venv\Scripts\python.exe -m pytest -q tests\unit\test_packaging.py` -> 4 passed
- `.venv\Scripts\python.exe -m pytest -q tests\unit\test_cli.py tests\unit\bat\test_cli.py tests\unit\carsandbids\test_cli.py` -> 51 passed
- `.venv\Scripts\python.exe -m pip install -e .` -> successfully installed `car-auction-etl-0.1.0`
- `$env:PATH = ".venv\Scripts;$env:PATH"; auction-etl --help` -> reached top-level CLI help
- `$env:PATH = ".venv\Scripts;$env:PATH"; auction-etl bat --help` -> reached BAT CLI help
- `$env:PATH = ".venv\Scripts;$env:PATH"; auction-etl cab --help` -> reached Cars and Bids CLI help
- `.venv\Scripts\python.exe -m app.cli --help` -> preserved module invocation

Closes #127