### PR TITLE
Reject withdrawn BAT listings before raw HTML storage

### DIFF
--- a/app/sources/bat/ingest.py
+++ b/app/sources/bat/ingest.py
@@ -80,6 +80,9 @@ def evaluate_listing_eligibility(soup, listing_id):
     if extract_country(soup) != BAT_ALLOWED_COUNTRY:
         return False, "listing outside US"
 
+    if is_withdrawn_listing(soup):
+        return False, "listing withdrawn"
+
     categories = extract_group_value(soup, "Category")
     if categories is None:
         return True, None
@@ -107,6 +110,14 @@ def extract_country(soup):
     if not country:
         return None
     return country
+
+
+def is_withdrawn_listing(soup):
+    available_info = soup.select_one(".listing-available-info")
+    if available_info is None:
+        return False
+
+    return "withdrawn" in available_info.get_text(" ", strip=True).lower()
 
 
 def extract_group_value(soup, label):

--- a/app/sources/bat/transform.py
+++ b/app/sources/bat/transform.py
@@ -247,7 +247,7 @@ def extract_sold_status(soup):
     if not available_info:
         raise ValueError("Could not parse sold status")
     text = available_info.get_text(" ", strip=True)
-    if "Bid to" in text or "Withdrawn on" in text:
+    if "Bid to" in text:
         return False
     elif "Sold for" in text:
         return True

--- a/tests/unit/bat/test_ingest.py
+++ b/tests/unit/bat/test_ingest.py
@@ -185,6 +185,63 @@ def test_evaluate_listing_eligibility_rejects_non_usa_country():
     )
 
 
+def test_evaluate_listing_eligibility_rejects_withdrawn_listing():
+    soup = BeautifulSoup(
+        """
+        <html>
+            <body>
+                <span class="show-country-name">USA</span>
+                <div class="listing-available-info">
+                    <span>Withdrawn on 4/29/26</span>
+                </div>
+            </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+    assert ingest.evaluate_listing_eligibility(soup, "2015-mercedes-benz-sprinter-11") == (
+        False,
+        "listing withdrawn",
+    )
+
+
+def test_evaluate_listing_eligibility_keeps_sold_listing_eligible():
+    soup = BeautifulSoup(
+        """
+        <html>
+            <body>
+                <span class="show-country-name">USA</span>
+                <div class="listing-available-info">
+                    <span>Sold for <strong>USD $19,750</strong></span>
+                </div>
+            </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+    assert ingest.evaluate_listing_eligibility(soup, "1967-porsche-911s-coupe") == (True, None)
+
+
+def test_evaluate_listing_eligibility_keeps_bid_to_listing_eligible():
+    soup = BeautifulSoup(
+        """
+        <html>
+            <body>
+                <span class="show-country-name">USA</span>
+                <div class="listing-available-info">
+                    <span>Bid to <strong>USD $19,750</strong></span>
+                </div>
+            </body>
+        </html>
+        """,
+        "html.parser",
+    )
+
+    assert ingest.evaluate_listing_eligibility(soup, "1967-porsche-911s-coupe") == (True, None)
+
+
 def test_evaluate_listing_eligibility_rejects_excluded_category():
     soup = BeautifulSoup(
         """

--- a/tests/unit/bat/test_transform.py
+++ b/tests/unit/bat/test_transform.py
@@ -911,7 +911,7 @@ def test_extract_bid_price_no_price_info():
     with pytest.raises(ValueError, match="Could not parse sale price"):
         transform.extract_sale_price(soup, product_data)
 
-def test_extract_sold_status_valid():
+def test_extract_sold_status_returns_true_for_sold_for():
     html_content = """
     <html>
         <body>
@@ -926,7 +926,7 @@ def test_extract_sold_status_valid():
     soup = BeautifulSoup(html_content, "html.parser")
     assert transform.extract_sold_status(soup) == True
 
-def test_extract_sold_status_not_sold():
+def test_extract_sold_status_returns_false_for_bid_to():
     html_content = """
     <html>
         <body>
@@ -940,6 +940,24 @@ def test_extract_sold_status_not_sold():
     """
     soup = BeautifulSoup(html_content, "html.parser")
     assert transform.extract_sold_status(soup) == False
+
+
+def test_extract_sold_status_rejects_withdrawn_on():
+    html_content = """
+    <html>
+        <body>
+            <div class="listing-available">
+                    <div class="listing-available-info">
+                        <span class="info-value noborder-tiny">Withdrawn on 4/29/26</span>
+                </div>
+            </div>
+        </body>
+    </html>
+    """
+    soup = BeautifulSoup(html_content, "html.parser")
+    with pytest.raises(ValueError, match="Could not parse sold status"):
+        transform.extract_sold_status(soup)
+
 
 def test_extract_sold_status_no_available_info():
     html_content = """


### PR DESCRIPTION
## Summary

- Reject withdrawn Bring a Trailer listing pages during ingest before raw HTML is stored.
- Keep otherwise valid `Sold for` and `Bid to` BAT listings eligible.
- Stop treating `Withdrawn on` as a valid transformed sold-status value.

## Validation

- `.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_ingest.py tests\unit\bat\test_transform.py tests\unit\bat\test_pipeline.py` (`114 passed`)
- `.venv\Scripts\python.exe -m pytest -q` (`343 passed`)

Closes #130