### PR TITLE
[codex] Allow BAT listings with null mileage

### DIFF
--- a/app/sources/bat/transform.py
+++ b/app/sources/bat/transform.py
@@ -104,7 +104,14 @@ def transform_listing_html(listing_id):
     make = parse_make(soup)
     model_raw = parse_model(soup)
     model_normalized = normalize_model(make, model_raw)
-    mileage = parse_mileage(find_detail_value(listing_details, r"\bmiles?\b|\btmu\b|\bunknown\b", "Mileage"))
+    mileage = parse_mileage(
+        find_detail_value(
+            listing_details,
+            r"\bmiles?\b|\btmu\b|\bunknown\b|\bmiles?\s+shown\b",
+            "Mileage",
+            required=False,
+        )
+    )
     vin = extract_vin(find_detail_value(listing_details, r"^Chassis:", "VIN"))
     sale_price = extract_sale_price(soup, product_data)
     sold = extract_sold_status(soup)
@@ -197,16 +204,21 @@ def get_listing_details(soup):
     return values
 
 # Find the corresponding value for a given field in the listing details
-def find_detail_value(values, pattern, field_name):
+def find_detail_value(values, pattern, field_name, required=True):
     for value in values:
         if re.search(pattern, value, re.IGNORECASE):
             return value
+    if not required:
+        return None
     raise ValueError(f"Could not parse {field_name}")
 
 def parse_mileage(raw_mileage):
+    if raw_mileage is None:
+        return None
+
     mileage = raw_mileage.strip().lower()
 
-    if "tmu" in mileage or "unknown" in mileage:
+    if "tmu" in mileage or "unknown" in mileage or "miles shown" in mileage:
         return None
 
     match = re.search(r"(\d{1,3}(?:,\d{3})*|\d+)(k)?\s+miles\b", mileage)

--- a/tests/unit/bat/test_transform.py
+++ b/tests/unit/bat/test_transform.py
@@ -286,6 +286,118 @@ def test_transform_listing_html_allows_missing_model(mocker):
     assert transformed["model_normalized"] is None
     assert transformed["year"] == 2004
 
+def test_transform_listing_html_allows_missing_mileage_detail(mocker):
+    html_content = """
+    <html>
+        <head>
+            <script type="application/ld+json">
+            {
+                "@context": "http://schema.org",
+                "@type": "Product",
+                "name": "One Owner BMW M3",
+                "offers": {
+                    "@type": "Offer",
+                    "priceCurrency": "USD",
+                    "price": 19750
+                }
+            }
+            </script>
+        </head>
+        <body>
+            <button class="group-title">
+                <strong class="group-title-label">Make</strong>
+                BMW
+            </button>
+            <button class="group-title">
+                <strong class="group-title-label">Model</strong>
+                M3
+            </button>
+            <div class="item">
+                <strong>Listing Details</strong>
+                <ul>
+                    <li>Chassis: WBSBL93414PN57203</li>
+                    <li>6-Speed Manual Transmission</li>
+                </ul>
+            </div>
+            <div class="listing-available-info">
+                <span>Sold for <strong>USD $19,750</strong></span>
+            </div>
+            <span class="date date-localize" data-timestamp="1774898451"></span>
+        </body>
+    </html>
+    """
+    mocker.patch.object(transform, "load_listing_html", return_value=html_content)
+
+    transformed = transform.transform_listing_html("2004-missing-mileage")
+
+    assert transformed["mileage"] is None
+    assert transformed["vin"] == "WBSBL93414PN57203"
+    assert transformed["transmission"] == "manual"
+
+
+@pytest.mark.parametrize(
+    ("listing_details", "error"),
+    [
+        (
+            """
+            <li>50,250 Miles</li>
+            <li>6-Speed Manual Transmission</li>
+            """,
+            "Could not parse VIN",
+        ),
+        (
+            """
+            <li>Chassis: WBSBL93414PN57203</li>
+            <li>50,250 Miles</li>
+            """,
+            "Could not parse Transmission",
+        ),
+    ],
+)
+def test_transform_listing_html_preserves_required_detail_failures(
+    mocker,
+    listing_details,
+    error,
+):
+    html_content = f"""
+    <html>
+        <head>
+            <script type="application/ld+json">
+            {{
+                "@context": "http://schema.org",
+                "@type": "Product",
+                "name": "One Owner BMW M3",
+                "offers": {{
+                    "@type": "Offer",
+                    "priceCurrency": "USD",
+                    "price": 19750
+                }}
+            }}
+            </script>
+        </head>
+        <body>
+            <button class="group-title">
+                <strong class="group-title-label">Make</strong>
+                BMW
+            </button>
+            <div class="item">
+                <strong>Listing Details</strong>
+                <ul>
+                    {listing_details}
+                </ul>
+            </div>
+            <div class="listing-available-info">
+                <span>Sold for <strong>USD $19,750</strong></span>
+            </div>
+            <span class="date date-localize" data-timestamp="1774898451"></span>
+        </body>
+    </html>
+    """
+    mocker.patch.object(transform, "load_listing_html", return_value=html_content)
+
+    with pytest.raises(ValueError, match=error):
+        transform.transform_listing_html("2004-required-field-failure")
+
 def test_get_product_json_ld_returns_product_data(tmp_path):
     # create a test HTML file with a valid JSON-LD script tag
     html_content = """
@@ -723,6 +835,7 @@ def test_parse_mileage_valid():
 def test_parse_mileage_TMU():
     assert transform.parse_mileage("TMU") == None
     assert transform.parse_mileage("Mileage Unknown") == None
+    assert transform.parse_mileage("miles shown") == None
 
 def test_parse_mileage_invalid():
     with pytest.raises(ValueError, match="Could not parse mileage"):


### PR DESCRIPTION
## Summary

- Allow Bring a Trailer transforms to return `mileage: None` when no mileage detail is present.
- Keep detail lookup strict by default for required fields like VIN and transmission.
- Treat `miles shown` as nullable mileage alongside `TMU` and `Mileage Unknown`.
- Add focused BAT transform tests for omitted mileage, nullable labels, and required-field failures.

## Root Cause

The BAT transform composed strict `find_detail_value(...)` lookup with `parse_mileage(...)`, so listings without a mileage detail failed before mileage could be represented as `None`.

## Validation

```powershell
.venv\Scripts\python.exe -m pytest -q tests\unit\bat\test_transform.py
.venv\Scripts\python.exe -m pytest -q
```

Results:

```text
77 passed in 0.45s
346 passed in 36.81s
```

Closes #131